### PR TITLE
Prevent suggestion commands from hanging or running untrusted code

### DIFF
--- a/docs/SNIPPET_SYNTAX.md
+++ b/docs/SNIPPET_SYNTAX.md
@@ -190,8 +190,24 @@ Suggestion commands are executed with non-login, non-interactive `bash -c` in
 the current working directory. Output is split into suggestions by real
 newlines and literal `\n` sequences. Blank suggestions are ignored.
 
-If a suggestion command fails, peanutbutter shows the error but still lets the
-user type a value manually.
+If a suggestion command fails or times out, peanutbutter shows the error but
+still lets the user type a value manually.
+
+#### Timeouts and opt-out
+
+Two `[suggestion_commands]` config options control command execution:
+
+```toml
+[suggestion_commands]
+# Maximum time a suggestion command may run (milliseconds). Default: 2000.
+# Commands that exceed this limit are killed; the variable falls back to
+# manual input.
+timeout_ms = 2000
+
+# Set to false to disable all suggestion command execution. Variables will
+# fall back to their static suggestions or manual input.
+allow_commands = true
+```
 
 ### Built-in Variable Names
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -24,6 +24,14 @@ state_file = "/home/me/.local/state/peanutbutter/state.tsv"
 # The terminal may still clamp this lower depending on available rows.
 height = 18
 
+[suggestion_commands]
+# Maximum time (ms) a suggestion command may run before being killed.
+# The variable falls back to manual input on timeout.
+timeout_ms = 2000
+
+# Set to false to disable all suggestion command execution globally.
+allow_commands = true
+
 [search]
 # How much frecency influences the final ranking relative to fuzzy score.
 # Higher values make your usage history matter more.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,6 +106,7 @@ where
         theme: app_config.theme.clone(),
         variables: app_config.variables.clone(),
         snippet_roots: paths.snippet_roots.clone(),
+        suggestion_commands: app_config.suggestion_commands.clone(),
         ..ExecuteOptions::default()
     };
     let outcome = runner(index, store.clone(), options)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,29 @@ pub struct AppConfig {
     pub variables: BTreeMap<String, VariableInputConfig>,
     /// Visual theme applied to the TUI.
     pub theme: Theme,
+    /// Controls how suggestion commands are executed.
+    pub suggestion_commands: SuggestionCommandsConfig,
+}
+
+/// Controls how suggestion commands (`<@name:cmd>` and `command =` entries) are
+/// executed. Applies globally to all suggestion commands in all snippets.
+#[derive(Debug, Clone)]
+pub struct SuggestionCommandsConfig {
+    /// How long (in milliseconds) a suggestion command may run before it is
+    /// killed and the variable falls back to manual input. Default: 2000.
+    pub timeout_ms: u64,
+    /// If `false`, no suggestion commands are executed at all; variables fall
+    /// back to their static suggestions or manual input. Default: `true`.
+    pub allow_commands: bool,
+}
+
+impl Default for SuggestionCommandsConfig {
+    fn default() -> Self {
+        Self {
+            timeout_ms: 2000,
+            allow_commands: true,
+        }
+    }
 }
 
 /// TUI layout parameters.
@@ -250,6 +273,10 @@ pub fn load() -> io::Result<AppConfig> {
         ui: UiConfig {
             height: file.ui.height.unwrap_or(20).max(1),
         },
+        suggestion_commands: SuggestionCommandsConfig {
+            timeout_ms: file.suggestion_commands.timeout_ms.unwrap_or(2000),
+            allow_commands: file.suggestion_commands.allow_commands.unwrap_or(true),
+        },
         search: SearchConfig {
             frecency_weight: file.search.frecency_weight.unwrap_or(250.0),
             fuzzy: FuzzyWeights {
@@ -293,6 +320,14 @@ struct FileConfig {
     variables: BTreeMap<String, VariableInputConfig>,
     #[serde(default)]
     theme: ThemeFileConfig,
+    #[serde(default)]
+    suggestion_commands: SuggestionCommandsFileConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SuggestionCommandsFileConfig {
+    timeout_ms: Option<u64>,
+    allow_commands: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/src/execute/app.rs
+++ b/src/execute/app.rs
@@ -1,5 +1,5 @@
 use crate::browse::{BrowseEntry, BrowseState, BrowseTree};
-use crate::config::{SearchConfig, Theme, VariableInputConfig};
+use crate::config::{SearchConfig, SuggestionCommandsConfig, Theme, VariableInputConfig};
 use crate::domain::{SnippetId, Variable, VariableSource, VariableSpec};
 use crate::frecency::FrecencyStore;
 use crate::fuzzy::FuzzyState;
@@ -52,11 +52,18 @@ pub trait SuggestionProvider {
 #[derive(Debug, Default, Clone)]
 pub struct SystemSuggestionProvider {
     variable_inputs: std::collections::BTreeMap<String, VariableInputConfig>,
+    suggestion_commands: SuggestionCommandsConfig,
 }
 
 impl SystemSuggestionProvider {
-    pub fn new(variable_inputs: std::collections::BTreeMap<String, VariableInputConfig>) -> Self {
-        Self { variable_inputs }
+    pub fn new(
+        variable_inputs: std::collections::BTreeMap<String, VariableInputConfig>,
+        suggestion_commands: SuggestionCommandsConfig,
+    ) -> Self {
+        Self {
+            variable_inputs,
+            suggestion_commands,
+        }
     }
 }
 
@@ -67,8 +74,14 @@ impl SuggestionProvider for SystemSuggestionProvider {
         cwd: &Path,
         local_variables: &std::collections::BTreeMap<String, VariableSpec>,
     ) -> io::Result<Vec<String>> {
+        let timeout_ms = self.suggestion_commands.timeout_ms;
         match &variable.source {
-            VariableSource::Command(cmd) => super::prompt::command_suggestions(cmd, cwd),
+            VariableSource::Command(cmd) => {
+                if !self.suggestion_commands.allow_commands {
+                    return Ok(Vec::new());
+                }
+                super::prompt::command_suggestions(cmd, cwd, timeout_ms)
+            }
             VariableSource::Default(_) => Ok(Vec::new()),
             VariableSource::Free => {
                 if let Some(config) = local_variables.get(&variable.name) {
@@ -76,7 +89,10 @@ impl SuggestionProvider for SystemSuggestionProvider {
                         return Ok(config.suggestions.clone());
                     }
                     if let Some(command) = &config.command {
-                        return super::prompt::command_suggestions(command, cwd);
+                        if !self.suggestion_commands.allow_commands {
+                            return Ok(Vec::new());
+                        }
+                        return super::prompt::command_suggestions(command, cwd, timeout_ms);
                     }
                 }
                 if let Some(config) = self.variable_inputs.get(&variable.name) {
@@ -84,7 +100,10 @@ impl SuggestionProvider for SystemSuggestionProvider {
                         return Ok(config.suggestions.clone());
                     }
                     if let Some(command) = &config.command {
-                        return super::prompt::command_suggestions(command, cwd);
+                        if !self.suggestion_commands.allow_commands {
+                            return Ok(Vec::new());
+                        }
+                        return super::prompt::command_suggestions(command, cwd, timeout_ms);
                     }
                 }
                 super::prompt::builtin_suggestions(&variable.name, cwd)

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -59,6 +59,8 @@ pub struct ExecuteOptions {
     /// Snippet roots used to build the original index. These are reused when
     /// the TUI reloads snippets after editing.
     pub snippet_roots: Vec<PathBuf>,
+    /// Controls how suggestion commands are executed (timeout, allow/deny).
+    pub suggestion_commands: config::SuggestionCommandsConfig,
 }
 
 impl Default for ExecuteOptions {
@@ -71,6 +73,7 @@ impl Default for ExecuteOptions {
             theme: config::Theme::default(),
             variables: std::collections::BTreeMap::new(),
             snippet_roots: Vec::new(),
+            suggestion_commands: config::SuggestionCommandsConfig::default(),
         }
     }
 }

--- a/src/execute/prompt.rs
+++ b/src/execute/prompt.rs
@@ -552,19 +552,60 @@ fn read_dir_entries(cwd: &Path, want_files: bool) -> io::Result<Vec<String>> {
 ///
 /// Each real newline and each literal `\n` in the output is treated as a
 /// separator, and blank items are dropped. Returns an error if the command
-/// exits non-zero, including the stderr output in the error message.
-pub(crate) fn command_suggestions(command: &str, cwd: &Path) -> io::Result<Vec<String>> {
+/// exits non-zero, times out, or produces no output, including stderr in the
+/// error message when available.
+///
+/// `timeout_ms` caps how long the command may run; processes that exceed it
+/// are killed and an error is returned so the caller can fall back gracefully.
+pub(crate) fn command_suggestions(
+    command: &str,
+    cwd: &Path,
+    timeout_ms: u64,
+) -> io::Result<Vec<String>> {
+    use std::io::Read;
+    use std::process::Stdio;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
     // `-c` (not `-lc`): a login shell would source the user's profile/bashrc,
     // whose startup output (e.g. `Agent pid NNNN` from ssh-agent) leaks into
     // stdout as fake suggestions and whose prompts (e.g. ssh-add passphrase)
     // block on captured stdin.
-    let output = Command::new("bash")
+    let mut child = Command::new("bash")
         .arg("-c")
         .arg(command)
         .current_dir(cwd)
-        .output()?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut stderr = child.stderr.take().expect("stderr is piped");
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        stdout.read_to_end(&mut out).ok();
+        stderr.read_to_end(&mut err).ok();
+        let _ = tx.send((out, err));
+    });
+
+    let (out_bytes, err_bytes) = match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
+        Ok(pair) => pair,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(io::Error::other(format!(
+                "suggestion command timed out after {timeout_ms}ms: {command}"
+            )));
+        }
+    };
+
+    let status = child.wait()?;
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&err_bytes).trim().to_string();
         let message = if stderr.is_empty() {
             format!("suggestion command failed: {command}")
         } else {
@@ -573,7 +614,7 @@ pub(crate) fn command_suggestions(command: &str, cwd: &Path) -> io::Result<Vec<S
         return Err(io::Error::other(message));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = String::from_utf8_lossy(&out_bytes);
     let mut values = Vec::new();
     for line in stdout.lines() {
         values.extend(

--- a/src/execute/terminal.rs
+++ b/src/execute/terminal.rs
@@ -47,7 +47,10 @@ pub fn run_execute(
     frecency: FrecencyStore,
     options: ExecuteOptions,
 ) -> io::Result<Option<ExecutionOutcome>> {
-    let provider = SystemSuggestionProvider::new(options.variables.clone());
+    let provider = SystemSuggestionProvider::new(
+        options.variables.clone(),
+        options.suggestion_commands.clone(),
+    );
     run_execute_with_provider(index, frecency, options, provider)
 }
 
@@ -425,7 +428,7 @@ mod tests {
             0,
             config::SearchConfig::default(),
             config::Theme::default(),
-            SystemSuggestionProvider::new(Default::default()),
+            SystemSuggestionProvider::new(Default::default(), Default::default()),
         )
     }
 
@@ -437,7 +440,7 @@ mod tests {
             0,
             config::SearchConfig::default(),
             config::Theme::default(),
-            SystemSuggestionProvider::new(Default::default()),
+            SystemSuggestionProvider::new(Default::default(), Default::default()),
         )
     }
 

--- a/src/execute/tests.rs
+++ b/src/execute/tests.rs
@@ -233,11 +233,53 @@ fn built_in_file_and_directory_sources_list_cwd_entries() {
 #[test]
 fn command_suggestions_split_literal_backslash_n_sequences() {
     let dir = Path::new(".");
-    let values = command_suggestions("printf 'GET\\\\nPOST\\\\nPUT'", dir).unwrap();
+    let values = command_suggestions("printf 'GET\\\\nPOST\\\\nPUT'", dir, 2000).unwrap();
     assert_eq!(
         values,
         vec!["GET".to_string(), "POST".to_string(), "PUT".to_string()]
     );
+}
+
+#[test]
+fn command_suggestions_times_out_and_returns_error() {
+    let dir = Path::new(".");
+    let err = command_suggestions("sleep 10", dir, 100).unwrap_err();
+    assert!(
+        err.to_string().contains("timed out"),
+        "expected timeout error, got: {err}"
+    );
+}
+
+#[test]
+fn system_provider_returns_empty_when_commands_disabled() {
+    use crate::config::{SuggestionCommandsConfig, VariableInputConfig};
+    use crate::domain::{Variable, VariableSource};
+    use crate::execute::SuggestionProvider;
+    use std::path::Path;
+
+    let mut variable_inputs = std::collections::BTreeMap::new();
+    variable_inputs.insert(
+        "target".to_string(),
+        VariableInputConfig {
+            command: Some("echo hi".to_string()),
+            ..Default::default()
+        },
+    );
+    let provider = crate::execute::SystemSuggestionProvider::new(
+        variable_inputs,
+        SuggestionCommandsConfig {
+            allow_commands: false,
+            timeout_ms: 2000,
+        },
+    );
+    let variable = Variable {
+        name: "target".to_string(),
+        source: VariableSource::Free,
+    };
+    let suggestions = provider
+        .suggestions(&variable, Path::new("."), &Default::default())
+        .unwrap();
+    assert!(suggestions.is_empty());
 }
 
 #[test]
@@ -563,7 +605,7 @@ fn variable_flow_uses_config_defined_inputs() {
         0,
         crate::config::SearchConfig::default(),
         crate::config::Theme::default(),
-        SystemSuggestionProvider::new(configured),
+        SystemSuggestionProvider::new(configured, Default::default()),
     );
 
     let _ = app.handle_key(press(KeyCode::Enter));
@@ -607,7 +649,7 @@ fn variable_flow_uses_file_local_specs_over_config_by_field() {
         0,
         crate::config::SearchConfig::default(),
         crate::config::Theme::default(),
-        SystemSuggestionProvider::new(configured),
+        SystemSuggestionProvider::new(configured, Default::default()),
     );
 
     let _ = app.handle_key(press(KeyCode::Enter));
@@ -651,7 +693,7 @@ fn file_local_suggestions_override_config_suggestions() {
         0,
         crate::config::SearchConfig::default(),
         crate::config::Theme::default(),
-        SystemSuggestionProvider::new(configured),
+        SystemSuggestionProvider::new(configured, Default::default()),
     );
 
     let _ = app.handle_key(press(KeyCode::Enter));
@@ -686,7 +728,7 @@ fn file_local_suggestions_without_default_leave_input_empty() {
         0,
         crate::config::SearchConfig::default(),
         crate::config::Theme::default(),
-        SystemSuggestionProvider::new(Default::default()),
+        SystemSuggestionProvider::new(Default::default(), Default::default()),
     );
 
     let _ = app.handle_key(press(KeyCode::Enter));
@@ -729,7 +771,7 @@ fn inline_default_overrides_config_default() {
         0,
         crate::config::SearchConfig::default(),
         crate::config::Theme::default(),
-        SystemSuggestionProvider::new(configured),
+        SystemSuggestionProvider::new(configured, Default::default()),
     );
 
     let _ = app.handle_key(press(KeyCode::Enter));
@@ -768,7 +810,7 @@ fn inline_default_overrides_file_local_default() {
         0,
         crate::config::SearchConfig::default(),
         crate::config::Theme::default(),
-        SystemSuggestionProvider::new(Default::default()),
+        SystemSuggestionProvider::new(Default::default(), Default::default()),
     );
 
     let _ = app.handle_key(press(KeyCode::Enter));
@@ -802,7 +844,7 @@ fn file_local_command_spec_populates_suggestions() {
         0,
         crate::config::SearchConfig::default(),
         crate::config::Theme::default(),
-        SystemSuggestionProvider::new(Default::default()),
+        SystemSuggestionProvider::new(Default::default(), Default::default()),
     );
 
     let _ = app.handle_key(press(KeyCode::Enter));


### PR DESCRIPTION
## Why

Snippet suggestion commands (`<@name:cmd>` and `command =` in config) ran with no time limit and no way to disable them. This is a safety gap: importing third-party snippet collections could expose users to unbounded shell execution or commands that hang the TUI indefinitely.

## What

- Add `[suggestion_commands]` section to `config.toml` with two options:
  - `timeout_ms` (default `2000`): any suggestion command that runs longer than this is killed; the variable falls back to manual input
  - `allow_commands` (default `true`): set to `false` to disable all suggestion command execution globally
- Rewrite `command_suggestions` to spawn the process, read stdout/stderr on a background thread, and use `recv_timeout` — the child is killed and a descriptive error is returned on timeout
- Thread `SuggestionCommandsConfig` through `ExecuteOptions` → `SystemSuggestionProvider` so both options are respected at every call site (inline `<@name:cmd>`, frontmatter `command`, and config-level `command`)
- Document options in `docs/SNIPPET_SYNTAX.md` and `examples/config.toml`
- Two new tests: `command_suggestions_times_out_and_returns_error` and `system_provider_returns_empty_when_commands_disabled`

## Verification

- `cargo fmt --check`
- `cargo build`
- `cargo test` (152 tests pass)
- `cargo clippy -- -D warnings -A dead_code`

## Review focus

- The timeout implementation spawns a thread to read stdout/stderr while keeping the `Child` handle on the calling thread for `kill()`. This avoids unsafe code and external crates — `libc` is already a dependency but not needed here since `std::process::Child::kill()` issues SIGKILL on Unix.
- `allow_commands = false` returns an empty suggestion list (not an error), so the variable prompt still appears; the user just has to type manually.

Closes #4
