### PR TITLE
Show fenced-block language tag in picker so users know what they're selecting

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -88,6 +88,8 @@ pub struct Snippet {
     pub body: String,
     /// Variables extracted from `body` in order of first appearance.
     pub variables: Vec<Variable>,
+    /// Language tag from the opening code fence (e.g. `"python"` for ` ```python `).
+    pub language: Option<String>,
 }
 
 /// A parsed Markdown file: its resolved paths, optional frontmatter, and all

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -207,6 +207,7 @@ mod tests {
                 description: String::new(),
                 body: "b".to_string(),
                 variables: vec![],
+                language: None,
             }],
         };
         let index = SnippetIndex::from_files([file]);

--- a/src/execute/render.rs
+++ b/src/execute/render.rs
@@ -851,6 +851,16 @@ mod tests {
     use std::path::PathBuf;
 
     fn snippet(name: &str, description: &str, body: &str, tags: &[&str]) -> IndexedSnippet {
+        snippet_with_language(name, description, body, tags, None)
+    }
+
+    fn snippet_with_language(
+        name: &str,
+        description: &str,
+        body: &str,
+        tags: &[&str],
+        language: Option<&str>,
+    ) -> IndexedSnippet {
         IndexedSnippet {
             path: PathBuf::from("demo.md"),
             snippet: Snippet {
@@ -859,7 +869,7 @@ mod tests {
                 description: description.to_string(),
                 body: body.to_string(),
                 variables: vec![],
-                language: None,
+                language: language.map(|l| l.to_string()),
             },
             relative_path: PathBuf::from("demo.md"),
             frontmatter: Frontmatter {
@@ -933,5 +943,40 @@ mod tests {
             .fg(ratatui::style::Color::Cyan)
             .patch(theme.fuzzy_highlight);
         assert!(home.iter().all(|styled| styled.style == expected));
+    }
+
+    #[test]
+    fn fuzzy_row_includes_language_after_separator() {
+        let theme = crate::config::Theme::default();
+        let mut scorer = FuzzyScorer::new();
+        let s = snippet_with_language("deploy", "desc", "kubectl apply", &[], Some("bash"));
+        let spans = fuzzy_snippet_row_spans(&theme, &s, None, &mut scorer, false);
+        let rendered: String = spans.iter().map(|span| span.content.as_ref()).collect();
+        assert!(
+            rendered.contains(" · bash"),
+            "expected language in row: {rendered}"
+        );
+    }
+
+    #[test]
+    fn preview_includes_lang_metadata_line() {
+        let theme = crate::config::Theme::default();
+        let mut scorer = FuzzyScorer::new();
+        let s = snippet_with_language("deploy", "desc", "kubectl apply", &[], Some("bash"));
+        let preview = render_snippet_preview_text(&s, 80, &theme, None, &mut scorer);
+        let rendered: String = preview
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            rendered.contains("lang"),
+            "expected lang label in preview: {rendered}"
+        );
+        assert!(
+            rendered.contains("bash"),
+            "expected language value in preview: {rendered}"
+        );
     }
 }

--- a/src/execute/render.rs
+++ b/src/execute/render.rs
@@ -576,6 +576,9 @@ fn fuzzy_snippet_row_spans(
         base,
         theme.fuzzy_highlight,
     ));
+    if let Some(lang) = snippet.language() {
+        spans.push(Span::styled(format!(" · {lang}"), theme.chrome));
+    }
     spans.push(Span::styled("]".to_string(), base));
     spans
 }
@@ -610,6 +613,14 @@ fn render_snippet_preview_text(
         ),
         theme,
     ));
+
+    if let Some(lang) = snippet.language() {
+        text.lines.push(metadata_line(
+            "lang",
+            vec![Span::raw(lang.to_string())],
+            theme,
+        ));
+    }
 
     if !snippet.frontmatter.tags.is_empty() {
         let mut tag_spans = Vec::new();
@@ -848,6 +859,7 @@ mod tests {
                 description: description.to_string(),
                 body: body.to_string(),
                 variables: vec![],
+                language: None,
             },
             relative_path: PathBuf::from("demo.md"),
             frontmatter: Frontmatter {

--- a/src/execute/terminal.rs
+++ b/src/execute/terminal.rs
@@ -455,6 +455,7 @@ mod tests {
                 description: String::new(),
                 body: body.to_string(),
                 variables: vec![],
+                language: None,
             }],
         }
     }

--- a/src/execute/tests.rs
+++ b/src/execute/tests.rs
@@ -61,6 +61,7 @@ fn snippet_file(rel: &str, name: &str, body: &str, variables: Vec<Variable>) -> 
             description: "desc".to_string(),
             body: body.to_string(),
             variables,
+            language: None,
         }],
     }
 }
@@ -76,6 +77,7 @@ fn snippet_file_with_slug(rel: &str, slug: &str, name: &str, body: &str) -> Snip
             description: "desc".to_string(),
             body: body.to_string(),
             variables: vec![],
+            language: None,
         }],
     }
 }
@@ -509,6 +511,7 @@ fn prompt_esc_in_browse_mode_preserves_browse_position() {
             description: "desc".to_string(),
             body: "git log <@x>".to_string(),
             variables,
+            language: None,
         }],
     };
     let index = SnippetIndex::from_files([file]);
@@ -1059,6 +1062,7 @@ fn browse_tab_resets_preview_scroll() {
             description: "desc".to_string(),
             body: "git log".to_string(),
             variables: vec![],
+            language: None,
         }],
     };
     let index = SnippetIndex::from_files([file]);
@@ -1099,6 +1103,7 @@ fn browse_entering_directory_resets_preview_scroll() {
             description: "desc".to_string(),
             body: "git log".to_string(),
             variables: vec![],
+            language: None,
         }],
     };
     let index = SnippetIndex::from_files([file]);

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -128,6 +128,9 @@ pub fn score_snippet(
         );
     }
 
+    // language is not scored: interpreter dispatch and language-aware filtering
+    // are deferred to a future config mapping and are out of scope for this PR.
+
     if matched { Some(total) } else { None }
 }
 

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -231,6 +231,7 @@ mod tests {
                 description: String::new(),
                 body: body.to_string(),
                 variables: vec![],
+                language: None,
             },
             relative_path: PathBuf::from(rel),
             frontmatter: Frontmatter {

--- a/src/index.rs
+++ b/src/index.rs
@@ -42,6 +42,9 @@ impl IndexedSnippet {
     pub fn tags(&self) -> &[String] {
         &self.frontmatter.tags
     }
+    pub fn language(&self) -> Option<&str> {
+        self.snippet.language.as_deref()
+    }
     pub fn relative_path_display(&self) -> String {
         self.relative_path.to_string_lossy().replace('\\', "/")
     }
@@ -164,6 +167,7 @@ mod tests {
                 description: "first".into(),
                 body: "echo a".into(),
                 variables: vec![],
+                language: None,
             }],
         };
         let file_b = SnippetFile {
@@ -176,6 +180,7 @@ mod tests {
                 description: "second".into(),
                 body: "echo b".into(),
                 variables: vec![],
+                language: None,
             }],
         };
         index.insert_file(file_a);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -218,6 +218,7 @@ enum State {
         heading: String,
         description: Vec<String>,
         fence: String,
+        language: Option<String>,
         body: Vec<String>,
     },
 }
@@ -259,13 +260,14 @@ fn parse_snippets(lines: &[&str], relative_path: &Path) -> Vec<Snippet> {
                         heading: h,
                         description: Vec::new(),
                     };
-                } else if let Some(fence) = parse_fence_open(line) {
+                } else if let Some((fence, language)) = parse_fence_open(line) {
                     let heading = std::mem::take(heading);
                     let description = std::mem::take(description);
                     state = State::InCode {
                         heading,
                         description,
                         fence,
+                        language,
                         body: Vec::new(),
                     };
                 } else {
@@ -276,17 +278,20 @@ fn parse_snippets(lines: &[&str], relative_path: &Path) -> Vec<Snippet> {
                 heading,
                 description,
                 fence,
+                language,
                 body,
             } => {
                 if is_fence_close(line, fence) {
                     let heading = std::mem::take(heading);
                     let description = std::mem::take(description);
+                    let language = std::mem::take(language);
                     let body = std::mem::take(body);
                     out.push(build_snippet(
                         relative_path,
                         heading,
                         description,
                         body,
+                        language,
                         &mut seen_slugs,
                     ));
                     state = State::Scanning;
@@ -327,7 +332,7 @@ fn parse_snippet_line_ranges(
                 if let Some(next_heading) = parse_snippet_heading(line) {
                     *heading = next_heading;
                     *start_line = abs_idx;
-                } else if let Some(fence) = parse_fence_open(line) {
+                } else if let Some((fence, _)) = parse_fence_open(line) {
                     let heading = std::mem::take(heading);
                     let start_line = *start_line;
                     state = RangeState::InCode {
@@ -372,13 +377,23 @@ fn parse_snippet_heading(line: &str) -> Option<String> {
     Some(text.to_string())
 }
 
-fn parse_fence_open(line: &str) -> Option<String> {
+/// Returns `(fence, language)` where `language` is the text after the backticks, if any.
+fn parse_fence_open(line: &str) -> Option<(String, Option<String>)> {
     let trimmed = line.trim_start();
     if !trimmed.starts_with("```") {
         return None;
     }
     let ticks: String = trimmed.chars().take_while(|c| *c == '`').collect();
-    if ticks.len() >= 3 { Some(ticks) } else { None }
+    if ticks.len() < 3 {
+        return None;
+    }
+    let lang = trimmed[ticks.len()..].trim();
+    let language = if lang.is_empty() {
+        None
+    } else {
+        Some(lang.to_string())
+    };
+    Some((ticks, language))
 }
 
 fn is_fence_close(line: &str, fence: &str) -> bool {
@@ -394,6 +409,7 @@ fn build_snippet(
     heading: String,
     description: Vec<String>,
     body: Vec<String>,
+    language: Option<String>,
     seen_slugs: &mut std::collections::HashMap<String, usize>,
 ) -> Snippet {
     let description = description.join("\n").trim().to_string();
@@ -410,6 +426,7 @@ fn build_snippet(
         description,
         body,
         variables,
+        language,
     }
 }
 
@@ -629,6 +646,20 @@ variables:
         let snippets = parse_snippets(&lines, &rel("x.md"));
         assert_eq!(snippets.len(), 2);
         assert_ne!(snippets[0].id, snippets[1].id);
+    }
+
+    #[test]
+    fn language_tag_is_parsed_from_fence() {
+        let content = "## Hello\n\n```python\nprint('hi')\n```\n";
+        let snippets = parse_snippets(&content.lines().collect::<Vec<_>>(), &rel("x.md"));
+        assert_eq!(snippets[0].language.as_deref(), Some("python"));
+    }
+
+    #[test]
+    fn no_language_tag_produces_none() {
+        let content = "## Hello\n\n```\necho hi\n```\n";
+        let snippets = parse_snippets(&content.lines().collect::<Vec<_>>(), &rel("x.md"));
+        assert_eq!(snippets[0].language, None);
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -76,6 +76,7 @@ mod tests {
                 description: String::new(),
                 body: body.to_string(),
                 variables: vec![],
+                language: None,
             }],
         }
     }


### PR DESCRIPTION
## Why

The picker showed no hint about what language a snippet was written in. Users browsing snippets couldn't tell at a glance whether they were looking at shell, Python, SQL, or anything else — they had to open the preview and read the body to find out.

## What

- Add `language: Option<String>` to the `Snippet` domain type, populated from the fenced code-block language tag (e.g. ` ```python ` → `"python"`). Snippets with plain ` ``` ` fences get `None` and behave exactly as before.
- Update `parse_fence_open` in `parser.rs` to return `(fence, language)` instead of just the fence string; thread `language` through the state machine and `build_snippet`.
- Expose `language()` on `IndexedSnippet`.
- Picker display changes:
  - **Fuzzy list row**: `snippet name  [relative/path · python]` — language appended inside the bracket after a `·` separator, styled with the chrome color so it's readable but subordinate.
  - **Preview pane**: `lang  \`python\`` metadata line inserted between `path` and `tags`.
- Two new parser unit tests: `language_tag_is_parsed_from_fence` and `no_language_tag_produces_none`.
- All existing `Snippet` struct literals in tests updated with `language: None`.

## Verification

- `cargo fmt --check`
- `cargo build`
- `cargo test` (154 tests pass, +2 new)
- `cargo clippy -- -D warnings -A dead_code`

## Review focus

- The language tag is captured verbatim from the fence line (`bash`, `python`, `sql`, etc.) with no normalisation — whatever the author typed is what displays. This is intentional: no canonical list exists in the codebase yet, and normalising silently could mask typos.
- Interpreter dispatch (the optional part of the issue) is not included here; that requires a config mapping and is a separate concern.

Closes #10
