### PR TITLE
feat(lint): add snippet lint command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode
 .idea
 .opencode
+.pi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "nucleo-matcher",
  "ratatui",
  "serde",
+ "serde_json",
  "termimad",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ libc = "0.2"
 nucleo-matcher = "0.3"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 termimad = "0.34"
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -136,6 +136,34 @@ Notes:
 2. `peanutbutter zsh [C+b]` — emit zsh integration script (eval it in `~/.zshrc`)
 3. `peanutbutter fish [C+b]` — emit fish integration script (source it in `config.fish`)
 4. `peanutbutter edit ...` — edit a snippet file in `$EDITOR`/`$VISUAL`
-5. `peanutbutter execute` — run the inline TUI; output can be piped, e.g. `peanutbutter execute | grep foo`
+5. `peanutbutter lint [--strict] [--json]` — check configured snippet roots for authoring problems
+6. `peanutbutter execute` — run the inline TUI; output can be piped, e.g. `peanutbutter execute | grep foo`
 
 All three shell integrations install a `pb` alias and wire up `pb edit <TAB>` completion.
+
+`pb lint` is read-only. It reports broken frontmatter, unused frontmatter/config variables, duplicate snippet slugs, suggestion-command failures, dry-run frecency GC orphans, and obvious static inline suggestion commands. Bare manual placeholders like `<@value>` are valid in normal mode. `--strict` adds style/structure checks such as undeclared manual placeholders, unbalanced fences, missing code-fence language tags, and confusing file-local variable overrides. Pretty output is written to stdout by default; `--json` writes a parseable object with stable `findings[].code` fields. Exit codes are `0` for no findings, `1` for lint findings, and `2` for operational failures that prevent lint from running.
+
+Important caveat: lint executes suggestion commands to verify them, using the same non-login `bash -c` behavior and configured timeout as runtime. If `suggestion_commands.allow_commands = false`, lint skips those commands and reports warning findings instead. Frecency GC checks are dry-run only and never reattach, purge, save, or write backups.
+
+Pretty output example:
+
+```text
+/path/to/snippets.md
+  warning:3 lint/unused-variable: frontmatter variable 'env' is not referenced by any snippet in this file
+```
+
+JSON output example:
+
+```json
+{
+  "findings": [
+    {
+      "severity": "warning",
+      "code": "lint/unused-variable",
+      "path": "/path/to/snippets.md",
+      "line": 3,
+      "message": "frontmatter variable 'env' is not referenced by any snippet in this file"
+    }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Notes:
 - Suggestion commands (both inline `<@name:cmd>` and `[variables.name] command = "..."`) run under non-login, non-interactive `bash -c`. They inherit `$PATH` from peanutbutter's parent process but do **not** source `~/.bash_profile` or `~/.bashrc`, so they can't use shell aliases or functions defined there. This is deliberate: a login shell's startup output (e.g. `Agent pid NNNN` from ssh-agent) would otherwise leak into the suggestion list, and any interactive prompt it triggers (e.g. an ssh-add passphrase) would hang the TUI.
 - `suggestion_commands.timeout_ms` caps how long any suggestion command may run (default `2000` ms); commands that exceed it are killed and the variable falls back to manual input
 - `suggestion_commands.allow_commands` set to `false` disables all suggestion command execution globally — variables fall back to static suggestions or manual input (useful when importing untrusted snippet collections)
+- `lint.<code>` config can disable or suppress specific lint findings. Use the lint code without the `lint/` prefix, e.g. `[lint.suggestion-command-failed]`. `disable = true` drops that lint entirely, `ignore_file` matches snippet paths relative to their snippet root, and `ignore_command` matches command text for command-backed lint findings. `ignore_file` and `ignore_command` accept either one glob string or a list of glob strings.
+
+```toml
+[lint.suggestion-command-failed]
+ignore_command = "*rg*"
+ignore_file = ["test*", "fixtures/*"]
+disable = false
+```
 
 ## Peanutbutter CLI
 

--- a/docs/SNIPPET_SYNTAX.md
+++ b/docs/SNIPPET_SYNTAX.md
@@ -58,8 +58,11 @@ These specs apply only to snippets in the same markdown file. They do not
 apply to other files.
 
 Malformed or unsupported frontmatter variable specs are ignored during normal
-execution. A future `pb check` command is expected to validate them more
-strictly.
+execution. Run `pb lint` to validate supported frontmatter syntax and variable
+expectations before opening the picker. Normal lint warns about variable specs
+that no snippet references. `pb lint --strict` additionally warns about style
+issues such as undeclared manual placeholders and confusing file-local variable
+overrides.
 
 ## Snippets
 
@@ -148,7 +151,9 @@ grep <@pattern> <@file>
 ```
 
 Prompts the user for a value. No inline default or inline suggestion command is
-attached to the placeholder.
+attached to the placeholder. This is valid for values that need human context;
+normal `pb lint` does not require every free-form placeholder to have a matching
+frontmatter or config definition.
 
 Example:
 
@@ -191,7 +196,9 @@ the current working directory. Output is split into suggestions by real
 newlines and literal `\n` sequences. Blank suggestions are ignored.
 
 If a suggestion command fails or times out, peanutbutter shows the error but
-still lets the user type a value manually.
+still lets the user type a value manually. `pb lint` also executes suggestion
+commands to verify them, using the configured timeout; when command execution is
+disabled, lint reports skipped command-backed variables as warnings instead.
 
 #### Timeouts and opt-out
 

--- a/docs/SNIPPET_SYNTAX.md
+++ b/docs/SNIPPET_SYNTAX.md
@@ -199,6 +199,9 @@ If a suggestion command fails or times out, peanutbutter shows the error but
 still lets the user type a value manually. `pb lint` also executes suggestion
 commands to verify them, using the configured timeout; when command execution is
 disabled, lint reports skipped command-backed variables as warnings instead.
+Specific lint findings can be suppressed in config with `[lint.<code>]` tables;
+for example, `[lint.suggestion-command-failed] ignore_command = "*rg*"` ignores
+expected `rg` failures for that lint.
 
 #### Timeouts and opt-out
 

--- a/docs/plans/lint-bigplan.md
+++ b/docs/plans/lint-bigplan.md
@@ -160,6 +160,8 @@ This deliverable updates user-facing docs so snippet authors understand how to r
 
 ## Issues
 
+- **2026-05-11 — agent:pi** — Added post-testing lint suppression scope: `[lint.<code>]` config supports `disable`, relative-path `ignore_file` globs, and command-text `ignore_command` globs.
+
 - **2026-05-11 — agent:pi** — Adjusted variable linting after design review: undeclared variables are now strict warnings only, and normal lint reports unused frontmatter/config variable definitions.
 
 - **2026-05-11 — agent:pi** — Implemented `pb lint` end-to-end: CLI flags/output model, normal and strict checks, GC dry-run orphan collection, docs, and verification with `cargo fmt --check`, `cargo test`, and `cargo clippy -- -D warnings -A dead_code`.

--- a/docs/plans/lint-bigplan.md
+++ b/docs/plans/lint-bigplan.md
@@ -1,0 +1,169 @@
+# BIGPLAN: Lint command
+
+## Plan Overview
+
+Add a read-only `pb lint` command that checks configured snippet roots for common authoring problems before they surprise users in the picker. The command should be useful both interactively and from scripts: pretty human output by default, JSON output behind a flag, and predictable exit codes. Done means `pb lint` can report the requested normal checks, optionally include stricter style checks via `--strict`, run frecency GC logic in dry-run mode only, and has tests covering both output modes and exit behavior.
+
+## Risks
+
+- **Suggestion commands have side effects** — Lint will execute suggestion commands to prove they work, which can be surprising if snippet collections contain commands with side effects. Mitigate by documenting that lint executes suggestions in the same non-login `bash -c` style as runtime, applying the existing timeout, and leaving mutating remediation out of scope.
+- **Parser currently discards malformed detail** — Existing parsing intentionally ignores malformed frontmatter and malformed placeholders, but lint needs diagnostics with file/line context. Mitigate by adding lint-specific validation paths that scan source text for findings instead of trying to infer every issue from the lossy runtime `SnippetFile` model.
+- **Markdown validation can expand scope quickly** — Strict-mode “validate markdown” could become a full CommonMark conformance project. Mitigate by defining this as parser-relevant markdown validation for snippet files: fence balance, snippet-section structure, and any existing markdown parser capability if a small dependency is chosen deliberately.
+
+## Plan Details
+
+`pb lint` is a non-interactive command over resolved snippet roots. It should not launch the TUI, write selected commands to stdout, or mutate the frecency store. Pretty output goes to stdout; operational errors go to stderr through existing `main.rs` error handling. Exit code semantics: `0` for no findings, `1` for lint findings, `2` for operational failures (config load failure, unreadable snippet root). When an individual snippet file is unreadable, emit a warning finding and continue rather than exiting `2`; reserve `2` for failures that prevent lint from running at all.
+
+### Finding model
+
+A minimal lint model should carry enough data for both pretty and JSON output without duplicating formatting logic:
+
+```text
+LintFinding {
+  severity: "error" | "warning",
+  code: stable machine-readable string (e.g. "lint/broken-frontmatter"),
+  path: snippet source path or state file path,
+  line: optional 1-based line number,
+  snippet_id: optional id when known,
+  message: short user-facing description,
+  detail: optional longer context,
+}
+```
+
+Canonical codes for all checks (define these as constants in `src/lint.rs`):
+
+| Code | Severity | Mode |
+|---|---|---|
+| `lint/broken-frontmatter` | error | normal |
+| `lint/undeclared-variable` | warning | strict |
+| `lint/unused-variable` | warning | normal |
+| `lint/duplicate-slug` | warning | normal |
+| `lint/suggestion-command-failed` | error | normal |
+| `lint/suggestion-command-timeout` | error | normal |
+| `lint/suggestion-commands-disabled` | warning | normal |
+| `lint/gc-orphan-reattachable` | warning | normal |
+| `lint/gc-orphan-unresolvable` | warning | normal |
+| `lint/static-inline-command` | warning | normal |
+| `lint/markdown-structure` | warning | strict |
+| `lint/missing-code-language` | warning | strict |
+| `lint/frontmatter-override` | warning | strict |
+
+Normal-mode checks should produce findings for broken frontmatter, unused frontmatter/config variables, duplicate slugs, failing suggestion commands, dry-run GC orphans, and inline command variables that should be frontmatter suggestions. Strict mode adds undeclared-variable warnings, markdown validation, missing language tags on snippet-defining code blocks, and frontmatter variables that override broader variable definitions in a confusing way.
+
+### Check interpretation
+
+- Broken frontmatter means a top-of-file `---` block is unterminated or cannot be parsed according to the supported frontmatter subset. Runtime may continue to ignore it, but lint should report it.
+- Undeclared variables means a free-form placeholder such as `<@name>` has no inline source, no file-local frontmatter variable spec, no config-defined variable spec, and is not a built-in variable (`file`, `directory`). Inline defaults and inline commands are self-declared. This is a strict-mode warning only because bare manual placeholders are valid when human context is required.
+- Unused variables means a file-local frontmatter variable spec is not referenced by any snippet in that file, or a config-defined variable is not referenced by any snippet across configured roots.
+- Duplicate slugs means two `##` snippets in the same relative path slugify to the same base slug; runtime currently appends numeric suffixes, but lint should report the collision so authors can rename headings deliberately.
+- Failing suggestion commands includes inline `<@name:command>` and frontmatter/config-backed `command = “...”` paths used by a snippet. Commands run with the snippet root as cwd (not the user's invocation cwd), under non-login `bash -c`, inheriting the parent `PATH`, with the existing timeout. When `allow_commands = false` is set in config, lint does not execute commands but emits a `lint/suggestion-commands-disabled` warning for each snippet that has command-backed variables so the user knows they were skipped.
+- “Invokes gc” means lint calls extracted orphan detection logic from `gc.rs` (not `run_with` directly, which mixes output with discovery) and reports orphaned frecency events as findings. It must not prompt, reattach, purge, save, or write a backup. Use two codes matching GC's own distinction: `lint/gc-orphan-reattachable` for orphans where GC would find a candidate snippet to reattach to, and `lint/gc-orphan-unresolvable` for orphans with no candidate. Put the candidate snippet ID in the `detail` field for reattachable orphans.
+- Inline command variables like `<@input:echo "a\nb\c">` should be reported when the command appears to be a static suggestion list better represented as a frontmatter `variables.<name>.suggestions` declaration. Keep the heuristic simple: obvious `echo`/`printf` static lists only, not arbitrary shell analysis.
+- Strict overriding checks should detect file-local frontmatter variables that reuse a name already configured globally and change suggestions or command behavior. The finding should suggest renaming when the local meaning is different; identical overlays or adding a default only can stay quiet.
+
+### Critical Files
+
+- `src/cli.rs` — add `Command::Lint`, CLI flags, command runner, and CLI-level tests.
+- `src/main.rs` — dispatch `lint`, print output, and map lint findings to the agreed exit code.
+- `src/parser.rs` — existing snippet/frontmatter parser; lint should reuse what is safe but add source-aware validation where runtime parsing is intentionally permissive.
+- `src/domain.rs` — may need public lint structs if the lint module exposes typed results.
+- `src/gc.rs` — extract or reuse dry-run orphan detection without mutating state or relying on human-formatted GC output.
+- `src/execute/prompt.rs` and `src/execute/app.rs` — existing suggestion command behavior and timeout semantics to mirror for lint.
+- `src/lib.rs` — declare a new `lint` module if implemented as `src/lint.rs`.
+- `docs/SNIPPET_SYNTAX.md` and `README.md` — document `pb lint`, strict mode, JSON output, and the fact that suggestion commands execute during lint.
+- `tests/` — integration coverage for CLI behavior and sample snippet roots.
+
+### Gotchas
+
+- Do not mix debug/status output into stdout for JSON mode; stdout must be parseable JSON when `--json` is set.
+- `serde` is available with `derive`, but `serde_json` is not currently in `Cargo.toml`; JSON output will need a deliberate dependency addition or a small manual serializer. Prefer adding `serde_json` if implementing real JSON.
+- Frontmatter parsing is currently custom and permissive, not general YAML. Lint should validate the supported subset unless the implementation intentionally introduces a real YAML parser.
+- Runtime duplicate slug handling makes IDs unique by suffixing; lint’s duplicate-slug check should look at the base slug before suffixing.
+- Suggestion commands run under non-login, non-interactive `bash -c` and inherit the parent `PATH`; lint should not source shell profiles either.
+- `gc::run_with` mixes orphan detection with formatted output and only returns aggregate counts — it cannot be called directly to produce per-orphan findings. Extract a pure `gc::collect_orphans(paths) -> Vec<GcOrphan>` function (or equivalent) that returns typed orphan records without writing output. The `GcOrphan` record should carry the event's snippet path/ID and the best reattachment candidate (if any) so lint can emit the two `gc-orphan-*` codes correctly.
+- `builtin_suggestions` (and the built-in variable name list) lives in `src/execute/prompt.rs` as `pub(crate)`. The lint module needs to know which variable names are built-ins (`file`, `directory`) to implement the undeclared-variable check. Either expose `is_builtin_variable(name: &str) -> bool` as `pub` from `execute/prompt.rs`, or move the constant set to `src/domain.rs`.
+
+### Pseudo-code / Sketches
+
+```text
+run_lint(paths, options, writer):
+  config = load app config
+  findings = []
+
+  for root in paths.snippet_roots:
+    for markdown file under root:
+      content = read file or return operational error
+      parsed = parse_file(file, root, content)
+      findings += lint_frontmatter_source(content)
+      findings += lint_duplicate_base_slugs(content, relative_path)
+      findings += lint_variables(parsed, config.variables)
+      findings += lint_suggestion_commands(parsed, config, cwd, timeout)
+      findings += lint_static_inline_suggestion_commands(parsed)
+      if options.strict:
+        findings += lint_markdown_structure(content)
+        findings += lint_missing_code_languages(parsed/source ranges)
+        findings += lint_frontmatter_overrides(parsed.frontmatter, config.variables)
+
+  findings += lint_gc_dry_run(paths)
+
+  if options.json:
+    write JSON array/object to stdout
+  else:
+    write grouped pretty findings to stdout
+
+  return has_findings(findings)
+```
+
+## Deliverables
+
+### Deliverable 1. CLI contract and output model
+
+This deliverable defines the user-facing command shape before implementing individual checks. It adds `pb lint` with `--strict` and `--json`, a shared `LintFinding` model, pretty rendering that lists findings with path and description, JSON rendering for scripts, and exit-code handling. Acceptance criteria: no findings exits `0`, findings exit `1`, operational failures (config load failure, unreadable snippet root) exit `2`, and JSON mode produces parseable machine output with stable codes.
+
+- [x] Add a `Lint` variant to `src/cli.rs` with `--strict` and `--json` flags.
+- [x] Add a `src/lint.rs` module with documented public option/result/finding types.
+- [x] Implement pretty output grouped or sorted by path with code, severity, line when available, and description.
+- [x] Implement JSON output with stable field names and no extra stdout text.
+- [x] Dispatch `pb lint` from `src/main.rs` and map outcomes to exit codes `0`, `1`, and operational error handling.
+- [x] Add CLI tests for argument parsing, output mode selection, and exit semantics where practical.
+
+### Deliverable 2. Normal lint checks
+
+This deliverable makes default `pb lint` useful for real snippet maintenance. It reports broken frontmatter, undeclared variables, duplicate base slugs, failing suggestion commands, dry-run GC findings, and static inline suggestion commands that should be frontmatter variables. The implementation should reuse existing parser, config, discovery, suggestion-command, and GC behavior where doing so stays simple, but add lint-specific source scanning where runtime parsing is too permissive.
+
+- [x] Validate top-of-file frontmatter delimiters and supported fields well enough to report broken frontmatter with file and line context.
+- [x] Report undeclared free-form variables that are not inline-sourced, file-local, config-defined, or built in.
+- [x] Report duplicate base slugs within the same relative snippet file before runtime numeric suffixing.
+- [x] Execute inline and resolved suggestion commands using the snippet root as cwd, with the existing timeout semantics; report failures/timeouts as findings. When `allow_commands = false`, emit `lint/suggestion-commands-disabled` per affected snippet instead of running commands.
+- [x] Extract `gc::collect_orphans` (or equivalent) from `gc.rs` returning typed per-orphan records without writing output. Call from lint; emit `lint/gc-orphan-reattachable` or `lint/gc-orphan-unresolvable` per orphan with candidate ID in `detail` when applicable.
+- [x] Detect obvious static inline command suggestions and suggest moving them into frontmatter `variables` suggestions.
+- [x] Add unit tests for each normal check, including at least one multi-root duplicate-id or GC-related case. For suggestion-command checks, test with portable commands (`echo`, `true`, `false`) and a command that sleeps past the timeout to verify timeout behavior. Add a test verifying lint runs against the explicitly configured snippet root(s), not a hardcoded default.
+
+### Deliverable 3. Strict-mode checks
+
+This deliverable adds opt-in stricter authoring checks without making the default command noisy. `pb lint --strict` should include every normal check plus markdown/snippet-structure validation, missing language tags on code fences that define snippets, and confusing local variable overrides. Strict findings follow the same output and exit-code rules as normal findings, but only appear when `--strict` is set.
+
+- [x] Define the concrete strict markdown validation scope in tests before implementation.
+- [x] Report unbalanced fences or malformed snippet-defining sections that the runtime parser would otherwise ignore.
+- [x] Report snippet-defining fenced code blocks with no language tag.
+- [x] Report file-local frontmatter variables that override config-defined variables with a different suggestion source and suggest renaming.
+- [x] Ensure strict-only findings are absent without `--strict` and present with `--strict`.
+
+### Deliverable 4. Documentation and examples
+
+This deliverable updates user-facing docs so snippet authors understand how to run lint and how to interpret its findings. It should document the command name, flags, exit behavior, output modes, strict mode, and the important safety caveat that suggestion commands are executed during lint while GC stays dry-run only.
+
+- [x] Update `README.md` CLI documentation to include `peanutbutter lint [--strict] [--json]`.
+- [x] Update `docs/SNIPPET_SYNTAX.md` to replace the future `pb check` wording with `pb lint` and describe the linted frontmatter/variable expectations.
+- [x] Add or update examples showing a pretty finding and representative JSON output.
+- [x] Run `cargo fmt --check`, `cargo test`, and `cargo clippy -- -D warnings -A dead_code` after implementation.
+
+## Issues
+
+- **2026-05-11 — agent:pi** — Adjusted variable linting after design review: undeclared variables are now strict warnings only, and normal lint reports unused frontmatter/config variable definitions.
+
+- **2026-05-11 — agent:pi** — Implemented `pb lint` end-to-end: CLI flags/output model, normal and strict checks, GC dry-run orphan collection, docs, and verification with `cargo fmt --check`, `cargo test`, and `cargo clippy -- -D warnings -A dead_code`.
+
+- **2026-05-11 — agent:claude (adversarial review, round 2)** — Plan reviewed by 2 adversarial sub-agents (Risks & Assumptions, Completeness & Scope). 11 findings; 10 merged into plan. Most significant changes: added canonical code registry to finding model, `gc::run_with` extraction made an explicit task, `allow_commands=false` behavior defined (skip+warn), two GC orphan codes to match GC's own distinction, suggestion-command cwd fixed to snippet root, exit code `2` committed as a hard spec, `builtin_suggestions` visibility gap called out as a Gotcha.
+
+- **2026-05-11 — agent:claude (adversarial review)** — Plan reviewed by 2 adversarial perspectives (Risks & Assumptions, Completeness & Scope). 4 findings; 4 merged into plan. Most significant changes: clarified lint side effects from suggestion-command execution, narrowed strict markdown validation scope, and made exit/output behavior an explicit deliverable.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,15 @@ pub enum Command {
         #[arg(default_value = "C+b")]
         binding: String,
     },
+    /// Check snippet files for authoring problems.
+    Lint {
+        /// Include stricter style and structure checks.
+        #[arg(long)]
+        strict: bool,
+        /// Emit JSON for scripts instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
     /// Garbage collect orphaned frecency events.
     Gc {
         /// Report changes without modifying the frecency store.
@@ -533,6 +542,15 @@ mod tests {
                 dry_run: true,
                 purge: true,
                 quiet: true,
+            })
+        );
+        assert_eq!(
+            Cli::try_parse_from(["peanutbutter", "lint", "--strict", "--json"])
+                .unwrap()
+                .command,
+            Some(Command::Lint {
+                strict: true,
+                json: true,
             })
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,25 @@ pub struct AppConfig {
     pub theme: Theme,
     /// Controls how suggestion commands are executed.
     pub suggestion_commands: SuggestionCommandsConfig,
+    /// Per-lint suppression and disable rules.
+    pub lint: LintConfig,
+}
+
+/// Per-lint suppression rules keyed by lint code without the `lint/` prefix.
+pub type LintConfig = BTreeMap<String, LintRuleConfig>;
+
+/// Suppression options for a single lint code.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct LintRuleConfig {
+    /// Disable this lint entirely.
+    pub disable: bool,
+    /// Glob patterns matched against snippet paths relative to their root.
+    #[serde(deserialize_with = "string_or_vec")]
+    pub ignore_file: Vec<String>,
+    /// Glob patterns matched against suggestion command text for command lints.
+    #[serde(deserialize_with = "string_or_vec")]
+    pub ignore_command: Vec<String>,
 }
 
 /// Controls how suggestion commands (`<@name:cmd>` and `command =` entries) are
@@ -295,6 +314,7 @@ pub fn load() -> io::Result<AppConfig> {
         },
         variables: file.variables,
         theme: Theme::from_raw(file.theme)?,
+        lint: file.lint,
     })
 }
 
@@ -322,6 +342,8 @@ struct FileConfig {
     theme: ThemeFileConfig,
     #[serde(default)]
     suggestion_commands: SuggestionCommandsFileConfig,
+    #[serde(default)]
+    lint: LintConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -377,6 +399,24 @@ struct ThemeFileConfig {
     prompt_active_fg: Option<String>,
     prompt_active_bg: Option<String>,
     error_fg: Option<String>,
+}
+
+fn string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        String(String),
+        Vec(Vec<String>),
+    }
+
+    Ok(match Option::<StringOrVec>::deserialize(deserializer)? {
+        Some(StringOrVec::String(value)) => vec![value],
+        Some(StringOrVec::Vec(values)) => values,
+        None => Vec::new(),
+    })
 }
 
 fn load_file_config(path: &PathBuf) -> io::Result<FileConfig> {
@@ -558,6 +598,21 @@ command = "find . -type f"
         assert_eq!(variable.default, None);
         assert!(variable.suggestions.is_empty());
         assert_eq!(variable.command.as_deref(), Some("find . -type f"));
+    }
+
+    #[test]
+    fn lint_rule_config_deserializes_string_and_list_patterns() {
+        let raw = r#"
+[lint.suggestion-command-failed]
+ignore_command = "*rg*"
+ignore_file = ["test*", "fixtures/*"]
+disable = true
+"#;
+        let parsed: FileConfig = toml::from_str(raw).unwrap();
+        let rule = parsed.lint.get("suggestion-command-failed").unwrap();
+        assert!(rule.disable);
+        assert_eq!(rule.ignore_command, vec!["*rg*"]);
+        assert_eq!(rule.ignore_file, vec!["test*", "fixtures/*"]);
     }
 
     #[test]

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -26,7 +26,7 @@ mod terminal;
 pub use app::{
     AppEvent, ExecutionApp, NavigationMode, SuggestionProvider, SystemSuggestionProvider,
 };
-pub use prompt::render_command;
+pub use prompt::{command_suggestions, render_command};
 pub use terminal::{execute_default, run_execute, run_execute_with_provider};
 
 /// The result of a completed TUI session: the snippet the user chose and the
@@ -80,8 +80,8 @@ impl Default for ExecuteOptions {
 
 #[cfg(test)]
 pub(crate) use prompt::{
-    active_prompt_style, builtin_suggestions, command_suggestions, placeholder_prompt_style,
-    render_command_text, unique_variables,
+    active_prompt_style, builtin_suggestions, placeholder_prompt_style, render_command_text,
+    unique_variables,
 };
 #[cfg(test)]
 pub(crate) use terminal::compact_viewport_height;

--- a/src/execute/prompt.rs
+++ b/src/execute/prompt.rs
@@ -557,11 +557,7 @@ fn read_dir_entries(cwd: &Path, want_files: bool) -> io::Result<Vec<String>> {
 ///
 /// `timeout_ms` caps how long the command may run; processes that exceed it
 /// are killed and an error is returned so the caller can fall back gracefully.
-pub(crate) fn command_suggestions(
-    command: &str,
-    cwd: &Path,
-    timeout_ms: u64,
-) -> io::Result<Vec<String>> {
+pub fn command_suggestions(command: &str, cwd: &Path, timeout_ms: u64) -> io::Result<Vec<String>> {
     use std::io::Read;
     use std::process::Stdio;
     use std::sync::mpsc;

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -18,6 +18,17 @@ pub struct GcOptions {
     pub quiet: bool,
 }
 
+/// One orphaned frecency id discovered without mutating the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcOrphan {
+    /// Orphaned snippet id from the frecency store.
+    pub id: SnippetId,
+    /// Number of events using this orphaned id.
+    pub events: usize,
+    /// Best current snippet id that GC would offer for reattachment, if any.
+    pub candidate_id: Option<SnippetId>,
+}
+
 /// Summary of a garbage-collection run over the frecency store.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GcResult {
@@ -52,13 +63,7 @@ pub fn run_with<R: BufRead, W: Write>(
 ) -> io::Result<GcResult> {
     let index = crate::index::load_from_roots(&paths.snippet_roots)?;
     let mut store = FrecencyStore::load(&paths.state_file)?;
-    let known_ids: HashSet<_> = index.iter().map(|entry| entry.id().clone()).collect();
-    let mut orphan_counts: BTreeMap<SnippetId, usize> = BTreeMap::new();
-    for event in store.events() {
-        if !known_ids.contains(&event.id) {
-            *orphan_counts.entry(event.id.clone()).or_default() += 1;
-        }
-    }
+    let orphan_counts = orphan_counts(&index, &store);
 
     let orphan_events = orphan_counts.values().sum();
     print_header(
@@ -145,6 +150,41 @@ pub fn run_with<R: BufRead, W: Write>(
         backup_path,
         saved,
     })
+}
+
+/// Collect orphaned frecency ids and likely reattachment candidates without
+/// prompting, purging, saving, or writing formatted output.
+pub fn collect_orphans(paths: &Paths) -> io::Result<Vec<GcOrphan>> {
+    let index = crate::index::load_from_roots(&paths.snippet_roots)?;
+    collect_orphans_with_index(paths, &index)
+}
+
+/// Collect orphaned frecency ids using an already-loaded snippet index.
+pub fn collect_orphans_with_index(
+    paths: &Paths,
+    index: &SnippetIndex,
+) -> io::Result<Vec<GcOrphan>> {
+    let store = FrecencyStore::load(&paths.state_file)?;
+    let orphan_counts = orphan_counts(index, &store);
+    Ok(orphan_counts
+        .into_iter()
+        .map(|(id, events)| GcOrphan {
+            candidate_id: best_candidate(&id, index).map(|candidate| candidate.id().clone()),
+            id,
+            events,
+        })
+        .collect())
+}
+
+fn orphan_counts(index: &SnippetIndex, store: &FrecencyStore) -> BTreeMap<SnippetId, usize> {
+    let known_ids: HashSet<_> = index.iter().map(|entry| entry.id().clone()).collect();
+    let mut orphan_counts: BTreeMap<SnippetId, usize> = BTreeMap::new();
+    for event in store.events() {
+        if !known_ids.contains(&event.id) {
+            *orphan_counts.entry(event.id.clone()).or_default() += 1;
+        }
+    }
+    orphan_counts
 }
 
 fn handle_purge<R: BufRead, W: Write>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! | [`discovery`] | Recursive `.md` file finder |
 //! | [`index`] | In-memory snippet index |
 //! | [`frecency`] | Usage history and recency/location scoring |
+//! | [`lint`] | Read-only snippet authoring checks |
 //! | [`gc`] | Frecency garbage collection |
 //! | [`fuzzy`] | nucleo-backed fuzzy matching |
 //! | [`search`] | Combined fuzzy + frecency ranking |
@@ -34,6 +35,7 @@ pub mod frecency;
 pub mod fuzzy;
 pub mod gc;
 pub mod index;
+pub mod lint;
 pub mod parser;
 pub mod search;
 

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,0 +1,993 @@
+//! Read-only snippet linting.
+
+use crate::config::{AppConfig, Paths, SuggestionCommandsConfig, VariableInputConfig};
+use crate::domain::{SnippetFile, SnippetId, VariableSource, VariableSpec};
+use crate::{discovery, parser};
+use serde::Serialize;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Broken or unterminated file frontmatter.
+pub const CODE_BROKEN_FRONTMATTER: &str = "lint/broken-frontmatter";
+/// Strict-mode placeholder has no inline, file-local, config, or built-in source.
+pub const CODE_UNDECLARED_VARIABLE: &str = "lint/undeclared-variable";
+/// Frontmatter or config variable definition is not referenced by snippets.
+pub const CODE_UNUSED_VARIABLE: &str = "lint/unused-variable";
+/// Two snippets in the same file slugify to the same base slug.
+pub const CODE_DUPLICATE_SLUG: &str = "lint/duplicate-slug";
+/// A suggestion command exited unsuccessfully.
+pub const CODE_SUGGESTION_COMMAND_FAILED: &str = "lint/suggestion-command-failed";
+/// A suggestion command exceeded the configured timeout.
+pub const CODE_SUGGESTION_COMMAND_TIMEOUT: &str = "lint/suggestion-command-timeout";
+/// Suggestion commands are disabled, so a command-backed variable was skipped.
+pub const CODE_SUGGESTION_COMMANDS_DISABLED: &str = "lint/suggestion-commands-disabled";
+/// Frecency GC found an orphan that has a likely current snippet candidate.
+pub const CODE_GC_ORPHAN_REATTACHABLE: &str = "lint/gc-orphan-reattachable";
+/// Frecency GC found an orphan with no likely current snippet candidate.
+pub const CODE_GC_ORPHAN_UNRESOLVABLE: &str = "lint/gc-orphan-unresolvable";
+/// Inline command appears to be a static suggestion list.
+pub const CODE_STATIC_INLINE_COMMAND: &str = "lint/static-inline-command";
+/// Strict markdown/snippet structure finding.
+pub const CODE_MARKDOWN_STRUCTURE: &str = "lint/markdown-structure";
+/// Strict snippet-defining code fence has no language tag.
+pub const CODE_MISSING_CODE_LANGUAGE: &str = "lint/missing-code-language";
+/// Strict file-local variable changes a global variable's suggestion source.
+pub const CODE_FRONTMATTER_OVERRIDE: &str = "lint/frontmatter-override";
+
+/// Runtime options for [`run`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LintOptions {
+    /// Include opt-in style and structure checks.
+    pub strict: bool,
+    /// Render parseable JSON instead of human-oriented text.
+    pub json: bool,
+}
+
+/// Severity attached to a lint finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LintSeverity {
+    /// A finding likely to produce broken runtime behavior.
+    Error,
+    /// A finding worth fixing but not necessarily fatal at runtime.
+    Warning,
+}
+
+/// A single lint diagnostic, shared by pretty and JSON renderers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LintFinding {
+    /// Finding severity.
+    pub severity: LintSeverity,
+    /// Stable machine-readable code.
+    pub code: &'static str,
+    /// Snippet source path, state path, or other relevant path.
+    pub path: PathBuf,
+    /// Optional 1-based source line.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    /// Optional snippet id when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snippet_id: Option<String>,
+    /// Short user-facing message.
+    pub message: String,
+    /// Optional longer context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Result of a lint run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LintResult {
+    /// All findings sorted by path, line, code, and message.
+    pub findings: Vec<LintFinding>,
+}
+
+impl LintResult {
+    /// Returns `true` when at least one finding was reported.
+    pub fn has_findings(&self) -> bool {
+        !self.findings.is_empty()
+    }
+}
+
+struct FileContext {
+    root: PathBuf,
+    path: PathBuf,
+    content: String,
+    parsed: SnippetFile,
+}
+
+/// Run lint over the configured snippet roots and write the selected output
+/// format to `writer`. This function is read-only: suggestion commands may be
+/// executed, but frecency GC is queried without saving or mutating state.
+pub fn run<W: Write>(
+    config: &AppConfig,
+    options: LintOptions,
+    writer: &mut W,
+) -> io::Result<LintResult> {
+    validate_roots(&config.paths.snippet_roots)?;
+    let mut findings = Vec::new();
+    let mut files = Vec::new();
+
+    for root in &config.paths.snippet_roots {
+        for path in discovery::discover_markdown_files(root)? {
+            let content = match fs::read_to_string(&path) {
+                Ok(content) => content,
+                Err(err) => {
+                    findings.push(finding(
+                        LintSeverity::Warning,
+                        CODE_MARKDOWN_STRUCTURE,
+                        path,
+                        None,
+                        None,
+                        "could not read snippet file".to_string(),
+                        Some(err.to_string()),
+                    ));
+                    continue;
+                }
+            };
+            let parsed = parser::parse_file(&path, root, &content);
+            files.push(FileContext {
+                root: root.clone(),
+                path,
+                content,
+                parsed,
+            });
+        }
+    }
+
+    for file in &files {
+        findings.extend(lint_frontmatter_source(&file.path, &file.content));
+        findings.extend(lint_duplicate_slugs(&file.path, &file.content));
+        findings.extend(lint_unused_file_variables(file));
+        findings.extend(lint_suggestion_commands(
+            file,
+            &config.variables,
+            &config.suggestion_commands,
+        ));
+        findings.extend(lint_static_inline_commands(file));
+        if options.strict {
+            findings.extend(lint_variables(file, &config.variables));
+            findings.extend(lint_markdown_structure(&file.path, &file.content));
+            findings.extend(lint_missing_code_languages(file));
+            findings.extend(lint_frontmatter_overrides(file, &config.variables));
+        }
+    }
+
+    findings.extend(lint_unused_config_variables(
+        &config.variables,
+        &config.paths.config_file,
+        &files,
+    ));
+    let index =
+        crate::index::SnippetIndex::from_files(files.iter().map(|file| file.parsed.clone()));
+    findings.extend(lint_gc(&config.paths, &index)?);
+    sort_findings(&mut findings);
+    let result = LintResult { findings };
+    if options.json {
+        render_json(&result, writer)?;
+    } else {
+        render_pretty(&result, writer)?;
+    }
+    Ok(result)
+}
+
+fn validate_roots(roots: &[PathBuf]) -> io::Result<()> {
+    for root in roots {
+        match fs::metadata(root) {
+            Ok(meta) if meta.is_dir() || meta.is_file() => {}
+            Ok(_) => {
+                return Err(io::Error::other(format!(
+                    "snippet root is not a file or directory: {}",
+                    root.display()
+                )));
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(io::Error::new(
+                    err.kind(),
+                    format!("unreadable snippet root {}: {err}", root.display()),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_json<W: Write>(result: &LintResult, writer: &mut W) -> io::Result<()> {
+    serde_json::to_writer_pretty(&mut *writer, result).map_err(io::Error::other)?;
+    writeln!(writer)
+}
+
+fn render_pretty<W: Write>(result: &LintResult, writer: &mut W) -> io::Result<()> {
+    if result.findings.is_empty() {
+        writeln!(writer, "No lint findings.")?;
+        return Ok(());
+    }
+    let mut current: Option<&Path> = None;
+    for finding in &result.findings {
+        if current != Some(finding.path.as_path()) {
+            if current.is_some() {
+                writeln!(writer)?;
+            }
+            writeln!(writer, "{}", finding.path.display())?;
+            current = Some(&finding.path);
+        }
+        let sev = match finding.severity {
+            LintSeverity::Error => "error",
+            LintSeverity::Warning => "warning",
+        };
+        let line = finding.line.map(|l| format!(":{l}")).unwrap_or_default();
+        let snippet = finding
+            .snippet_id
+            .as_deref()
+            .map(|id| format!(" [{id}]"))
+            .unwrap_or_default();
+        writeln!(
+            writer,
+            "  {sev}{} {}{}: {}",
+            line, finding.code, snippet, finding.message
+        )?;
+        if let Some(detail) = &finding.detail {
+            writeln!(writer, "    {detail}")?;
+        }
+    }
+    Ok(())
+}
+
+fn lint_frontmatter_source(path: &Path, content: &str) -> Vec<LintFinding> {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.first().map(|l| l.trim()) != Some("---") {
+        return Vec::new();
+    }
+    let Some(end) = lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim() == "---")
+        .map(|(idx, _)| idx)
+    else {
+        return vec![finding(
+            LintSeverity::Error,
+            CODE_BROKEN_FRONTMATTER,
+            path.to_path_buf(),
+            Some(1),
+            None,
+            "frontmatter block is not terminated".to_string(),
+            None,
+        )];
+    };
+    let mut out = Vec::new();
+    let mut i = 1;
+    while i < end {
+        let trimmed = lines[i].trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            i += 1;
+            continue;
+        }
+        if !trimmed.contains(':') && !trimmed.starts_with('-') {
+            out.push(finding(
+                LintSeverity::Error,
+                CODE_BROKEN_FRONTMATTER,
+                path.to_path_buf(),
+                Some(i + 1),
+                None,
+                "frontmatter line is not a supported key/value entry".to_string(),
+                None,
+            ));
+        }
+        if let Some((key, value)) = trimmed.split_once(':') {
+            if key.trim().is_empty() {
+                out.push(finding(
+                    LintSeverity::Error,
+                    CODE_BROKEN_FRONTMATTER,
+                    path.to_path_buf(),
+                    Some(i + 1),
+                    None,
+                    "frontmatter key is empty".to_string(),
+                    None,
+                ));
+            }
+            if value.trim().starts_with('[') && !value.trim().ends_with(']') {
+                out.push(finding(
+                    LintSeverity::Error,
+                    CODE_BROKEN_FRONTMATTER,
+                    path.to_path_buf(),
+                    Some(i + 1),
+                    None,
+                    "inline list is not closed".to_string(),
+                    None,
+                ));
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+fn lint_duplicate_slugs(path: &Path, content: &str) -> Vec<LintFinding> {
+    let mut first: HashMap<String, usize> = HashMap::new();
+    let mut out = Vec::new();
+    for (idx, line) in content.lines().enumerate() {
+        if let Some(heading) = snippet_heading(line) {
+            let slug = slugify(&heading);
+            if let Some(first_line) = first.get(&slug) {
+                out.push(finding(
+                    LintSeverity::Warning,
+                    CODE_DUPLICATE_SLUG,
+                    path.to_path_buf(),
+                    Some(idx + 1),
+                    None,
+                    format!("snippet heading duplicates base slug '{slug}'"),
+                    Some(format!("first occurrence is on line {first_line}")),
+                ));
+            } else {
+                first.insert(slug, idx + 1);
+            }
+        }
+    }
+    out
+}
+
+fn lint_variables(
+    file: &FileContext,
+    globals: &BTreeMap<String, VariableInputConfig>,
+) -> Vec<LintFinding> {
+    let ranges = parser::snippet_line_ranges(&file.parsed.relative_path, &file.content);
+    let mut line_by_id = HashMap::new();
+    for range in ranges {
+        line_by_id.insert(range.id, range.start_line + 1);
+    }
+    let mut out = Vec::new();
+    for snippet in &file.parsed.snippets {
+        let mut seen = HashSet::new();
+        for variable in &snippet.variables {
+            if !seen.insert(variable.name.clone())
+                || !matches!(variable.source, VariableSource::Free)
+            {
+                continue;
+            }
+            if is_builtin_variable(&variable.name)
+                || file
+                    .parsed
+                    .frontmatter
+                    .variables
+                    .contains_key(&variable.name)
+                || globals.contains_key(&variable.name)
+            {
+                continue;
+            }
+            out.push(finding(LintSeverity::Warning, CODE_UNDECLARED_VARIABLE, file.path.clone(), line_by_id.get(&snippet.id).copied(), Some(snippet.id.clone()), format!("variable '{}' has no declared source", variable.name), Some("add an inline default/command, a file-local frontmatter variable, or a global variable config if this is not intentionally manual input".to_string())));
+        }
+    }
+    out
+}
+
+fn lint_unused_file_variables(file: &FileContext) -> Vec<LintFinding> {
+    let referenced = referenced_variables(file);
+    let lines = frontmatter_variable_lines(&file.content);
+    file.parsed
+        .frontmatter
+        .variables
+        .keys()
+        .filter(|name| !referenced.contains(*name))
+        .map(|name| {
+            finding(
+                LintSeverity::Warning,
+                CODE_UNUSED_VARIABLE,
+                file.path.clone(),
+                lines.get(name).copied(),
+                None,
+                format!(
+                    "frontmatter variable '{name}' is not referenced by any snippet in this file"
+                ),
+                Some(
+                    "remove the variable definition or add a matching <@name> placeholder"
+                        .to_string(),
+                ),
+            )
+        })
+        .collect()
+}
+
+fn lint_unused_config_variables(
+    globals: &BTreeMap<String, VariableInputConfig>,
+    config_file: &Path,
+    files: &[FileContext],
+) -> Vec<LintFinding> {
+    let mut referenced = HashSet::new();
+    for file in files {
+        referenced.extend(referenced_variables(file));
+    }
+    globals
+        .keys()
+        .filter(|name| !referenced.contains(*name))
+        .map(|name| {
+            finding(
+                LintSeverity::Warning,
+                CODE_UNUSED_VARIABLE,
+                config_file.to_path_buf(),
+                None,
+                None,
+                format!("config variable '{name}' is not referenced by any snippet"),
+                Some(
+                    "remove the variable definition or add a matching <@name> placeholder"
+                        .to_string(),
+                ),
+            )
+        })
+        .collect()
+}
+
+fn referenced_variables(file: &FileContext) -> HashSet<String> {
+    file.parsed
+        .snippets
+        .iter()
+        .flat_map(|snippet| {
+            snippet
+                .variables
+                .iter()
+                .map(|variable| variable.name.clone())
+        })
+        .collect()
+}
+
+fn frontmatter_variable_lines(content: &str) -> HashMap<String, usize> {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.first().map(|line| line.trim()) != Some("---") {
+        return HashMap::new();
+    }
+    let Some(end) = lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim() == "---")
+        .map(|(idx, _)| idx)
+    else {
+        return HashMap::new();
+    };
+
+    let mut out = HashMap::new();
+    let Some(variables_line) = lines[..end]
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim() == "variables:")
+        .map(|(idx, _)| idx)
+    else {
+        return out;
+    };
+
+    for (idx, line) in lines.iter().enumerate().take(end).skip(variables_line + 1) {
+        let trimmed = line.trim_start();
+        let indent = line.len() - trimmed.len();
+        if indent == 0 || trimmed.is_empty() || trimmed.starts_with('#') {
+            break;
+        }
+        if let Some((name, rest)) = trimmed.split_once(':')
+            && rest.trim().is_empty()
+        {
+            out.insert(name.trim().to_string(), idx + 1);
+        }
+    }
+    out
+}
+
+fn lint_suggestion_commands(
+    file: &FileContext,
+    globals: &BTreeMap<String, VariableInputConfig>,
+    config: &SuggestionCommandsConfig,
+) -> Vec<LintFinding> {
+    let mut out = Vec::new();
+    for snippet in &file.parsed.snippets {
+        let commands = command_sources(snippet, &file.parsed.frontmatter.variables, globals);
+        for (name, command) in commands {
+            if !config.allow_commands {
+                out.push(finding(LintSeverity::Warning, CODE_SUGGESTION_COMMANDS_DISABLED, file.path.clone(), None, Some(snippet.id.clone()), format!("suggestion command for variable '{name}' was skipped because commands are disabled"), None));
+                continue;
+            }
+            match crate::execute::command_suggestions(&command, &file.root, config.timeout_ms) {
+                Ok(_) => {}
+                Err(err) => {
+                    let msg = err.to_string();
+                    let code = if msg.contains("timed out") {
+                        CODE_SUGGESTION_COMMAND_TIMEOUT
+                    } else {
+                        CODE_SUGGESTION_COMMAND_FAILED
+                    };
+                    out.push(finding(
+                        LintSeverity::Error,
+                        code,
+                        file.path.clone(),
+                        None,
+                        Some(snippet.id.clone()),
+                        format!("suggestion command for variable '{name}' failed"),
+                        Some(msg),
+                    ));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn command_sources(
+    snippet: &crate::domain::Snippet,
+    locals: &BTreeMap<String, VariableSpec>,
+    globals: &BTreeMap<String, VariableInputConfig>,
+) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for variable in &snippet.variables {
+        if !seen.insert(variable.name.clone()) {
+            continue;
+        }
+        match &variable.source {
+            VariableSource::Command(command) => out.push((variable.name.clone(), command.clone())),
+            VariableSource::Free => {
+                if let Some(command) = locals
+                    .get(&variable.name)
+                    .and_then(|spec| spec.command.clone())
+                    .or_else(|| {
+                        globals
+                            .get(&variable.name)
+                            .and_then(|spec| spec.command.clone())
+                    })
+                {
+                    out.push((variable.name.clone(), command));
+                }
+            }
+            VariableSource::Default(_) => {}
+        }
+    }
+    out
+}
+
+fn lint_static_inline_commands(file: &FileContext) -> Vec<LintFinding> {
+    let mut out = Vec::new();
+    for snippet in &file.parsed.snippets {
+        for variable in &snippet.variables {
+            let VariableSource::Command(command) = &variable.source else {
+                continue;
+            };
+            if looks_static_command(command) {
+                out.push(finding(
+                    LintSeverity::Warning,
+                    CODE_STATIC_INLINE_COMMAND,
+                    file.path.clone(),
+                    None,
+                    Some(snippet.id.clone()),
+                    format!(
+                        "inline command for variable '{}' looks like a static suggestion list",
+                        variable.name
+                    ),
+                    Some(
+                        "prefer frontmatter variables.<name>.suggestions for static lists"
+                            .to_string(),
+                    ),
+                ));
+            }
+        }
+    }
+    out
+}
+
+fn lint_markdown_structure(path: &Path, content: &str) -> Vec<LintFinding> {
+    let mut out = Vec::new();
+    let mut in_fence: Option<(String, usize)> = None;
+    let mut open_heading: Option<(String, usize, bool)> = None;
+    for (idx, line) in content.lines().enumerate() {
+        let line_no = idx + 1;
+        if let Some((fence, _)) = &in_fence {
+            if is_fence_close(line, fence) {
+                in_fence = None;
+                if let Some((_, _, has_code)) = &mut open_heading {
+                    *has_code = true;
+                }
+            }
+            continue;
+        }
+        if let Some(heading) = snippet_heading(line) {
+            if let Some((previous, previous_line, false)) =
+                open_heading.replace((heading, line_no, false))
+            {
+                out.push(finding(
+                    LintSeverity::Warning,
+                    CODE_MARKDOWN_STRUCTURE,
+                    path.to_path_buf(),
+                    Some(previous_line),
+                    None,
+                    format!("snippet section '{previous}' has no code fence"),
+                    None,
+                ));
+            }
+        } else if let Some(fence) = fence_open(line) {
+            in_fence = Some((fence, line_no));
+        }
+    }
+    if let Some((_, start)) = in_fence {
+        out.push(finding(
+            LintSeverity::Warning,
+            CODE_MARKDOWN_STRUCTURE,
+            path.to_path_buf(),
+            Some(start),
+            None,
+            "code fence is not closed".to_string(),
+            None,
+        ));
+    }
+    if let Some((heading, line, false)) = open_heading {
+        out.push(finding(
+            LintSeverity::Warning,
+            CODE_MARKDOWN_STRUCTURE,
+            path.to_path_buf(),
+            Some(line),
+            None,
+            format!("snippet section '{heading}' has no code fence"),
+            None,
+        ));
+    }
+    out
+}
+
+fn lint_missing_code_languages(file: &FileContext) -> Vec<LintFinding> {
+    let ranges = parser::snippet_line_ranges(&file.parsed.relative_path, &file.content);
+    let mut line_by_id = HashMap::new();
+    for range in ranges {
+        line_by_id.insert(range.id, range.start_line + 1);
+    }
+    file.parsed
+        .snippets
+        .iter()
+        .filter(|snippet| snippet.language.is_none())
+        .map(|snippet| {
+            finding(
+                LintSeverity::Warning,
+                CODE_MISSING_CODE_LANGUAGE,
+                file.path.clone(),
+                line_by_id.get(&snippet.id).copied(),
+                Some(snippet.id.clone()),
+                "snippet code fence has no language tag".to_string(),
+                None,
+            )
+        })
+        .collect()
+}
+
+fn lint_frontmatter_overrides(
+    file: &FileContext,
+    globals: &BTreeMap<String, VariableInputConfig>,
+) -> Vec<LintFinding> {
+    let mut out = Vec::new();
+    for (name, local) in &file.parsed.frontmatter.variables {
+        let Some(global) = globals.get(name) else {
+            continue;
+        };
+        let local_source = suggestion_source(local);
+        let global_source = suggestion_source(global);
+        if local_source != global_source && local_source != "none" && global_source != "none" {
+            out.push(finding(
+                LintSeverity::Warning,
+                CODE_FRONTMATTER_OVERRIDE,
+                file.path.clone(),
+                Some(1),
+                None,
+                format!("file-local variable '{name}' overrides a global suggestion source"),
+                Some("rename the local variable if it means something different".to_string()),
+            ));
+        }
+    }
+    out
+}
+
+fn lint_gc(paths: &Paths, index: &crate::index::SnippetIndex) -> io::Result<Vec<LintFinding>> {
+    let mut out = Vec::new();
+    for orphan in crate::gc::collect_orphans_with_index(paths, index)? {
+        let (code, detail) = match orphan.candidate_id {
+            Some(candidate) => (
+                CODE_GC_ORPHAN_REATTACHABLE,
+                Some(format!("candidate: {candidate}")),
+            ),
+            None => (CODE_GC_ORPHAN_UNRESOLVABLE, None),
+        };
+        out.push(finding(
+            LintSeverity::Warning,
+            code,
+            paths.state_file.clone(),
+            None,
+            Some(orphan.id),
+            format!("orphaned frecency id has {} event(s)", orphan.events),
+            detail,
+        ));
+    }
+    Ok(out)
+}
+
+fn finding(
+    severity: LintSeverity,
+    code: &'static str,
+    path: PathBuf,
+    line: Option<usize>,
+    snippet_id: Option<SnippetId>,
+    message: String,
+    detail: Option<String>,
+) -> LintFinding {
+    LintFinding {
+        severity,
+        code,
+        path,
+        line,
+        snippet_id: snippet_id.map(|id| id.to_string()),
+        message,
+        detail,
+    }
+}
+
+fn sort_findings(findings: &mut [LintFinding]) {
+    findings.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then(a.line.cmp(&b.line))
+            .then(a.code.cmp(b.code))
+            .then(a.message.cmp(&b.message))
+    });
+}
+
+fn is_builtin_variable(name: &str) -> bool {
+    matches!(name, "file" | "directory")
+}
+
+fn snippet_heading(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("##")?;
+    if rest.starts_with('#') {
+        return None;
+    }
+    let text = rest.trim();
+    (!text.is_empty()).then(|| text.to_string())
+}
+
+fn fence_open(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with("```") {
+        return None;
+    }
+    let ticks: String = trimmed.chars().take_while(|c| *c == '`').collect();
+    (ticks.len() >= 3).then_some(ticks)
+}
+
+fn is_fence_close(line: &str, fence: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with(fence) && trimmed.chars().all(|c| c == '`') && trimmed.len() >= fence.len()
+}
+
+fn slugify(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut last_dash = true;
+    for c in input.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        "snippet".to_string()
+    } else {
+        out
+    }
+}
+
+fn looks_static_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    trimmed.starts_with("echo ") || trimmed.starts_with("printf ")
+}
+
+fn suggestion_source(spec: &VariableSpec) -> &'static str {
+    if spec.command.is_some() {
+        "command"
+    } else if !spec.suggestions.is_empty() {
+        "suggestions"
+    } else {
+        "none"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{FrecencyConfig, FuzzyWeights, SearchConfig, Theme, UiConfig};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        let path = std::env::temp_dir().join(format!(
+            "pb-lint-{prefix}-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn config(root: PathBuf) -> AppConfig {
+        AppConfig {
+            paths: Paths {
+                snippet_roots: vec![root.clone()],
+                state_file: root.join("state.tsv"),
+                config_file: root.join("config.toml"),
+            },
+            ui: UiConfig::default(),
+            search: SearchConfig {
+                frecency_weight: 250.0,
+                fuzzy: FuzzyWeights::default(),
+                frecency: FrecencyConfig::default(),
+            },
+            variables: BTreeMap::new(),
+            theme: Theme::default(),
+            suggestion_commands: SuggestionCommandsConfig {
+                timeout_ms: 50,
+                allow_commands: true,
+            },
+        }
+    }
+
+    #[test]
+    fn undeclared_variable_is_strict_warning_and_json_is_parseable() {
+        let root = temp_dir("undeclared");
+        fs::write(
+            root.join("snippets.md"),
+            "## Demo\n\n```bash\necho <@name>\n```\n",
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        let normal = run(
+            &config(root.clone()),
+            LintOptions {
+                strict: false,
+                json: true,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(
+            !normal
+                .findings
+                .iter()
+                .any(|f| f.code == CODE_UNDECLARED_VARIABLE)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert!(json["findings"].is_array());
+
+        out.clear();
+        let strict = run(
+            &config(root),
+            LintOptions {
+                strict: true,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        let finding = strict
+            .findings
+            .iter()
+            .find(|f| f.code == CODE_UNDECLARED_VARIABLE)
+            .unwrap();
+        assert_eq!(finding.severity, LintSeverity::Warning);
+    }
+
+    #[test]
+    fn unused_frontmatter_variable_is_reported() {
+        let root = temp_dir("unused-frontmatter");
+        fs::write(
+            root.join("snippets.md"),
+            "---\nvariables:\n  unused:\n    suggestions: [a]\n  used:\n    suggestions: [b]\n---\n\n## Demo\n\n```bash\necho <@used>\n```\n",
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        let result = run(
+            &config(root),
+            LintOptions {
+                strict: false,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(result.findings.iter().any(|finding| {
+            finding.code == CODE_UNUSED_VARIABLE
+                && finding.message.contains("frontmatter variable 'unused'")
+        }));
+        assert!(!result.findings.iter().any(|finding| {
+            finding.code == CODE_UNUSED_VARIABLE && finding.message.contains("'used'")
+        }));
+    }
+
+    #[test]
+    fn unused_config_variable_is_reported() {
+        let root = temp_dir("unused-config");
+        fs::write(
+            root.join("snippets.md"),
+            "## Demo\n\n```bash\necho <@used>\n```\n",
+        )
+        .unwrap();
+        let mut cfg = config(root);
+        cfg.variables.insert(
+            "used".to_string(),
+            VariableSpec {
+                suggestions: vec!["a".to_string()],
+                ..VariableSpec::default()
+            },
+        );
+        cfg.variables.insert(
+            "unused".to_string(),
+            VariableSpec {
+                suggestions: vec!["b".to_string()],
+                ..VariableSpec::default()
+            },
+        );
+        let mut out = Vec::new();
+        let result = run(
+            &cfg,
+            LintOptions {
+                strict: false,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(result.findings.iter().any(|finding| {
+            finding.code == CODE_UNUSED_VARIABLE
+                && finding.message.contains("config variable 'unused'")
+        }));
+        assert!(!result.findings.iter().any(|finding| {
+            finding.code == CODE_UNUSED_VARIABLE && finding.message.contains("'used'")
+        }));
+    }
+
+    #[test]
+    fn strict_missing_language_is_opt_in() {
+        let root = temp_dir("strict");
+        fs::write(root.join("snippets.md"), "## Demo\n\n```\necho ok\n```\n").unwrap();
+        let mut out = Vec::new();
+        let normal = run(
+            &config(root.clone()),
+            LintOptions {
+                strict: false,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(
+            !normal
+                .findings
+                .iter()
+                .any(|f| f.code == CODE_MISSING_CODE_LANGUAGE)
+        );
+        out.clear();
+        let strict = run(
+            &config(root),
+            LintOptions {
+                strict: true,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(
+            strict
+                .findings
+                .iter()
+                .any(|f| f.code == CODE_MISSING_CODE_LANGUAGE)
+        );
+    }
+}

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,6 +1,6 @@
 //! Read-only snippet linting.
 
-use crate::config::{AppConfig, Paths, SuggestionCommandsConfig, VariableInputConfig};
+use crate::config::{AppConfig, LintConfig, Paths, SuggestionCommandsConfig, VariableInputConfig};
 use crate::domain::{SnippetFile, SnippetId, VariableSource, VariableSpec};
 use crate::{discovery, parser};
 use serde::Serialize;
@@ -75,6 +75,10 @@ pub struct LintFinding {
     /// Optional longer context.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    #[serde(skip)]
+    suppress_path: Option<String>,
+    #[serde(skip)]
+    suppress_command: Option<String>,
 }
 
 /// Result of a lint run.
@@ -163,6 +167,8 @@ pub fn run<W: Write>(
     let index =
         crate::index::SnippetIndex::from_files(files.iter().map(|file| file.parsed.clone()));
     findings.extend(lint_gc(&config.paths, &index)?);
+    attach_suppress_paths(&mut findings, &files);
+    findings.retain(|finding| !is_suppressed(finding, &config.lint));
     sort_findings(&mut findings);
     let result = LintResult { findings };
     if options.json {
@@ -496,15 +502,18 @@ fn lint_suggestion_commands(
                     } else {
                         CODE_SUGGESTION_COMMAND_FAILED
                     };
-                    out.push(finding(
-                        LintSeverity::Error,
-                        code,
-                        file.path.clone(),
-                        None,
-                        Some(snippet.id.clone()),
-                        format!("suggestion command for variable '{name}' failed"),
-                        Some(msg),
-                    ));
+                    out.push(
+                        finding(
+                            LintSeverity::Error,
+                            code,
+                            file.path.clone(),
+                            None,
+                            Some(snippet.id.clone()),
+                            format!("suggestion command for variable '{name}' failed"),
+                            Some(msg),
+                        )
+                        .with_suppress_command(command.clone()),
+                    );
                 }
             }
         }
@@ -552,21 +561,24 @@ fn lint_static_inline_commands(file: &FileContext) -> Vec<LintFinding> {
                 continue;
             };
             if looks_static_command(command) {
-                out.push(finding(
-                    LintSeverity::Warning,
-                    CODE_STATIC_INLINE_COMMAND,
-                    file.path.clone(),
-                    None,
-                    Some(snippet.id.clone()),
-                    format!(
-                        "inline command for variable '{}' looks like a static suggestion list",
-                        variable.name
-                    ),
-                    Some(
-                        "prefer frontmatter variables.<name>.suggestions for static lists"
-                            .to_string(),
-                    ),
-                ));
+                out.push(
+                    finding(
+                        LintSeverity::Warning,
+                        CODE_STATIC_INLINE_COMMAND,
+                        file.path.clone(),
+                        None,
+                        Some(snippet.id.clone()),
+                        format!(
+                            "inline command for variable '{}' looks like a static suggestion list",
+                            variable.name
+                        ),
+                        Some(
+                            "prefer frontmatter variables.<name>.suggestions for static lists"
+                                .to_string(),
+                        ),
+                    )
+                    .with_suppress_command(command.clone()),
+                );
             }
         }
     }
@@ -721,6 +733,67 @@ fn finding(
         snippet_id: snippet_id.map(|id| id.to_string()),
         message,
         detail,
+        suppress_path: None,
+        suppress_command: None,
+    }
+}
+
+fn attach_suppress_paths(findings: &mut [LintFinding], files: &[FileContext]) {
+    for finding in findings {
+        if finding.suppress_path.is_some() {
+            continue;
+        }
+        if let Some(file) = files.iter().find(|file| file.path == finding.path) {
+            finding.suppress_path = Some(
+                file.parsed
+                    .relative_path
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+            );
+        }
+    }
+}
+
+impl LintFinding {
+    fn with_suppress_command(mut self, command: String) -> Self {
+        self.suppress_command = Some(command);
+        self
+    }
+}
+
+fn is_suppressed(finding: &LintFinding, config: &LintConfig) -> bool {
+    let key = finding.code.strip_prefix("lint/").unwrap_or(finding.code);
+    let Some(rule) = config.get(key) else {
+        return false;
+    };
+    rule.disable
+        || finding.suppress_path.as_deref().is_some_and(|path| {
+            rule.ignore_file
+                .iter()
+                .any(|pattern| glob_matches(pattern, path))
+        })
+        || finding.suppress_command.as_deref().is_some_and(|command| {
+            rule.ignore_command
+                .iter()
+                .any(|pattern| glob_matches(pattern, command))
+        })
+}
+
+fn glob_matches(pattern: &str, value: &str) -> bool {
+    glob_matches_bytes(pattern.as_bytes(), value.as_bytes())
+}
+
+fn glob_matches_bytes(pattern: &[u8], value: &[u8]) -> bool {
+    match (pattern, value) {
+        ([], []) => true,
+        ([], _) => false,
+        ([b'*', rest @ ..], _) => {
+            glob_matches_bytes(rest, value)
+                || (!value.is_empty() && glob_matches_bytes(pattern, &value[1..]))
+        }
+        ([b'?', rest @ ..], [_, value_rest @ ..]) => glob_matches_bytes(rest, value_rest),
+        ([p, rest @ ..], [v, value_rest @ ..]) if p == v => glob_matches_bytes(rest, value_rest),
+        _ => false,
     }
 }
 
@@ -802,7 +875,9 @@ fn suggestion_source(spec: &VariableSpec) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{FrecencyConfig, FuzzyWeights, SearchConfig, Theme, UiConfig};
+    use crate::config::{
+        FrecencyConfig, FuzzyWeights, LintRuleConfig, SearchConfig, Theme, UiConfig,
+    };
     use std::sync::atomic::{AtomicU64, Ordering};
 
     fn temp_dir(prefix: &str) -> PathBuf {
@@ -832,6 +907,7 @@ mod tests {
             },
             variables: BTreeMap::new(),
             theme: Theme::default(),
+            lint: BTreeMap::new(),
             suggestion_commands: SuggestionCommandsConfig {
                 timeout_ms: 50,
                 allow_commands: true,
@@ -951,6 +1027,108 @@ mod tests {
         assert!(!result.findings.iter().any(|finding| {
             finding.code == CODE_UNUSED_VARIABLE && finding.message.contains("'used'")
         }));
+    }
+
+    #[test]
+    fn lint_config_can_disable_lint() {
+        let root = temp_dir("disable");
+        fs::write(
+            root.join("snippets.md"),
+            "## Demo\n\n```bash\necho <@name>\n```\n",
+        )
+        .unwrap();
+        let mut cfg = config(root);
+        cfg.lint.insert(
+            "undeclared-variable".to_string(),
+            LintRuleConfig {
+                disable: true,
+                ..LintRuleConfig::default()
+            },
+        );
+        let mut out = Vec::new();
+        let result = run(
+            &cfg,
+            LintOptions {
+                strict: true,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(
+            !result
+                .findings
+                .iter()
+                .any(|finding| finding.code == CODE_UNDECLARED_VARIABLE)
+        );
+    }
+
+    #[test]
+    fn lint_config_can_ignore_relative_file_glob() {
+        let root = temp_dir("ignore-file");
+        fs::write(
+            root.join("test-snippets.md"),
+            "## Demo\n\n```bash\necho <@name>\n```\n",
+        )
+        .unwrap();
+        let mut cfg = config(root);
+        cfg.lint.insert(
+            "undeclared-variable".to_string(),
+            LintRuleConfig {
+                ignore_file: vec!["test*".to_string()],
+                ..LintRuleConfig::default()
+            },
+        );
+        let mut out = Vec::new();
+        let result = run(
+            &cfg,
+            LintOptions {
+                strict: true,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(
+            !result
+                .findings
+                .iter()
+                .any(|finding| finding.code == CODE_UNDECLARED_VARIABLE)
+        );
+    }
+
+    #[test]
+    fn lint_config_can_ignore_command_glob() {
+        let root = temp_dir("ignore-command");
+        fs::write(
+            root.join("snippets.md"),
+            "## Demo\n\n```bash\necho <@file:rg --files '*.nope'>\n```\n",
+        )
+        .unwrap();
+        let mut cfg = config(root);
+        cfg.lint.insert(
+            "suggestion-command-failed".to_string(),
+            LintRuleConfig {
+                ignore_command: vec!["*rg*".to_string()],
+                ..LintRuleConfig::default()
+            },
+        );
+        let mut out = Vec::new();
+        let result = run(
+            &cfg,
+            LintOptions {
+                strict: false,
+                json: false,
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert!(
+            !result
+                .findings
+                .iter()
+                .any(|finding| finding.code == CODE_SUGGESTION_COMMAND_FAILED)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,12 @@ fn main() {
         Ok(config) => config,
         Err(err) => {
             eprintln!("{BINARY_NAME}: {err}");
-            std::process::exit(1);
+            let code = if std::env::args().any(|arg| arg == "lint") {
+                2
+            } else {
+                1
+            };
+            std::process::exit(code);
         }
     };
     let paths = app_config.paths.clone();
@@ -70,6 +75,26 @@ fn main() {
             }
         }
         cli::Command::Edit { path } => cli::run_edit_command(&paths, path.as_deref()).map(|_| ()),
+        cli::Command::Lint { strict, json } => {
+            let mut stdout = io::stdout();
+            match peanutbutter::lint::run(
+                &app_config,
+                peanutbutter::lint::LintOptions { strict, json },
+                &mut stdout,
+            ) {
+                Ok(result) => {
+                    let _ = stdout.flush();
+                    if result.has_findings() {
+                        std::process::exit(1);
+                    }
+                    Ok(())
+                }
+                Err(err) => {
+                    eprintln!("{BINARY_NAME}: {err}");
+                    std::process::exit(2);
+                }
+            }
+        }
         cli::Command::Gc {
             dry_run,
             purge,


### PR DESCRIPTION
## Why

Snippet authors need a non-interactive way to catch authoring mistakes before the picker surprises them, but early user testing showed lint also needs escape hatches for expected failures such as `rg` returning exit code 1 when no files match a glob.

## What

- Add `peanutbutter lint [--strict] [--json]` with stable finding codes, pretty output, JSON output, and exit codes for clean/finding/operational-failure cases.
- Implement normal lint checks for broken frontmatter, unused frontmatter/config variables, duplicate slugs, suggestion command failures/timeouts/disabled commands, static inline command suggestions, and dry-run frecency GC orphans.
- Add strict-only checks for undeclared manual placeholders, markdown/snippet structure, missing code-fence language tags, and confusing frontmatter variable overrides.
- Extract typed GC orphan collection so lint can report frecency orphans without prompting, saving, purging, or writing backups.
- Add `[lint.<code>]` config to disable specific lints or suppress by relative snippet file glob / command glob.
- Document `pb lint`, JSON output, strict mode, suggestion-command side effects, and lint suppression config.

## Verification

- `cargo fmt --check`
- `cargo test` (188 unit tests + 7 integration tests pass)
- `cargo clippy -- -D warnings -A dead_code`
- pre-commit hooks on commits: `cargo fmt`, `cargo build`, `cargo test`, `cargo clippy -- -D warnings -A dead_code`
- pre-push hook: strict clippy

## Review focus

- Lint executes suggestion commands by design to verify them; suppression config is intended for expected command failures like `rg` with no matches.
- `ignore_file` matches paths relative to snippet roots for portability.
- Glob matching is intentionally small (`*` and `?`) rather than introducing a dependency.
- `lint/undeclared-variable` is strict-only because bare `<@value>` placeholders are valid manual inputs.
