### PR TITLE
feat(theme): add named theme selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Notes:
 - `search.frecency_weight` controls how much frecency influences the combined search ordering
 - `search.frecency.*` tunes the time/location/frequency balance for ranking
 - `search.fuzzy.*` tunes how much each snippet field contributes to fuzzy matching
-- `theme.*` currently controls the main selection and prompt colors; colors accept common names like `red`, `dark_gray`, `white`, or `#RRGGBB`
+- `theme.name` selects a built-in theme (`default`, `gruvbox`, `catppuccin`, `nord`, or `monochrome`); `theme.*` color values override that base and accept common names like `red`, `dark_gray`, `white`, or `#RRGGBB`. Use `--theme <name>` to select a clean named theme from the CLI.
 - `variables.<name>` defines reusable inputs for free-form placeholders like `<@http_method>` or `<@kube_context>`
 - A configured variable can provide either `suggestions = [...]` or `command = "..."`, and may also provide `default = "..."`
 - Suggestion commands (both inline `<@name:cmd>` and `[variables.name] command = "..."`) run under non-login, non-interactive `bash -c`. They inherit `$PATH` from peanutbutter's parent process but do **not** source `~/.bash_profile` or `~/.bashrc`, so they can't use shell aliases or functions defined there. This is deliberate: a login shell's startup output (e.g. `Agent pid NNNN` from ssh-agent) would otherwise leak into the suggestion list, and any interactive prompt it triggers (e.g. an ssh-add passphrase) would hang the TUI.
@@ -145,9 +145,9 @@ disable = false
 3. `peanutbutter fish [C+b]` — emit fish integration script (source it in `config.fish`)
 4. `peanutbutter edit ...` — edit a snippet file in `$EDITOR`/`$VISUAL`
 5. `peanutbutter lint [--strict] [--json]` — check configured snippet roots for authoring problems
-6. `peanutbutter execute` — run the inline TUI; output can be piped, e.g. `peanutbutter execute | grep foo`
+6. `peanutbutter execute [--theme <name>]` — run the inline TUI; output can be piped, e.g. `peanutbutter execute | grep foo`
 
-All three shell integrations install a `pb` alias and wire up `pb edit <TAB>` completion.
+All three shell integrations install a `pb` alias and wire up `pb edit <TAB>` plus `--theme <TAB>` completion.
 
 `pb lint` is read-only. It reports broken frontmatter, unused frontmatter/config variables, duplicate snippet slugs, suggestion-command failures, dry-run frecency GC orphans, and obvious static inline suggestion commands. Bare manual placeholders like `<@value>` are valid in normal mode. `--strict` adds style/structure checks such as undeclared manual placeholders, unbalanced fences, missing code-fence language tags, and confusing file-local variable overrides. Pretty output is written to stdout by default; `--json` writes a parseable object with stable `findings[].code` fields. Exit codes are `0` for no findings, `1` for lint findings, and `2` for operational failures that prevent lint from running.
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -76,6 +76,12 @@ path = 10
 body = 8
 
 [theme]
+# Select a built-in base theme:
+#   default, gruvbox, catppuccin, nord, monochrome
+# A CLI flag like `peanutbutter execute --theme nord` overrides this name and
+# skips the per-color overrides below.
+name = "default"
+
 # Colors accept common names like:
 #   red, blue, white, dark_gray
 # Or #RRGGBB hex values.
@@ -98,6 +104,17 @@ prompt_active_bg = "#f4d35e"
 
 # Error foreground.
 error_fg = "red"
+
+# To define a complete inline custom theme, set `name = "custom"` above and
+# provide every required base color in `[theme.custom]`:
+# [theme.custom]
+# accent = "#c678dd"
+# muted = "#5c6370"
+# selected_bg = "#3e4451"
+# selected_fg = "#abb2bf"
+# prompt_fg = "#282c34"
+# prompt_bg = "#61afef"
+# error_fg = "#e06c75"
 
 # Reusable predefined variable inputs.
 #

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,9 @@ const DEFAULT_EDIT_PATH: &str = "snippets.md";
 #[command(name = BINARY_NAME, about = "terminal snippet manager")]
 #[command(version)]
 pub struct Cli {
+    /// Built-in or custom theme name to use for the interactive TUI.
+    #[arg(long, global = true, value_name = "NAME")]
+    pub theme: Option<String>,
     #[command(subcommand)]
     pub command: Option<Command>,
 }
@@ -78,9 +81,12 @@ pub enum Command {
         #[arg(long)]
         json: bool,
     },
-    /// Internal bash completion helper for `edit`.
+    /// Internal shell completion helper for `edit`.
     #[command(hide = true)]
     CompleteEdit { current: Option<String> },
+    /// Internal shell completion helper for `--theme`.
+    #[command(hide = true)]
+    CompleteTheme { current: Option<String> },
 }
 
 /// Result returned by [`run_execute_command`].
@@ -114,8 +120,9 @@ pub fn after_help(paths: &Paths) -> String {
 pub fn run_execute_command<W: Write>(
     paths: &Paths,
     writer: &mut W,
+    theme_name: Option<&str>,
 ) -> io::Result<ExecuteCommandResult> {
-    run_execute_command_with(paths, writer, execute::run_execute)
+    run_execute_command_with(paths, writer, theme_name, execute::run_execute)
 }
 
 /// Testable variant of [`run_execute_command`] that accepts a custom `runner`
@@ -123,6 +130,7 @@ pub fn run_execute_command<W: Write>(
 pub fn run_execute_command_with<W, F>(
     paths: &Paths,
     writer: &mut W,
+    theme_name: Option<&str>,
     runner: F,
 ) -> io::Result<ExecuteCommandResult>
 where
@@ -132,7 +140,7 @@ where
     let index = crate::index::load_from_roots(&paths.snippet_roots)?;
     let mut store = FrecencyStore::load(&paths.state_file)?;
     let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let app_config = crate::config::load()?;
+    let app_config = crate::config::load_with_theme_override(theme_name)?;
     let options = ExecuteOptions {
         cwd: cwd.clone(),
         viewport_height: app_config.ui.height,
@@ -507,7 +515,22 @@ mod tests {
     fn clap_recognizes_expected_commands() {
         assert_eq!(
             Cli::try_parse_from(["peanutbutter"]).unwrap(),
-            Cli { command: None }
+            Cli {
+                theme: None,
+                command: None,
+            }
+        );
+        assert_eq!(
+            Cli::try_parse_from(["peanutbutter", "--theme", "nord"])
+                .unwrap()
+                .theme,
+            Some("nord".to_string())
+        );
+        assert_eq!(
+            Cli::try_parse_from(["peanutbutter", "execute", "--theme", "gruvbox"])
+                .unwrap()
+                .theme,
+            Some("gruvbox".to_string())
         );
         assert_eq!(
             Cli::try_parse_from(["peanutbutter", "execute"])
@@ -835,13 +858,14 @@ mod tests {
         let paths = test_paths(&root);
 
         let mut out = Vec::new();
-        let result = run_execute_command_with(&paths, &mut out, |_index, _store, _options| {
-            Ok(Some(ExecutionOutcome {
-                snippet_id: SnippetId::new("snippets.md", "echo"),
-                command: "echo hi".to_string(),
-            }))
-        })
-        .unwrap();
+        let result =
+            run_execute_command_with(&paths, &mut out, None, |_index, _store, _options| {
+                Ok(Some(ExecutionOutcome {
+                    snippet_id: SnippetId::new("snippets.md", "echo"),
+                    command: "echo hi".to_string(),
+                }))
+            })
+            .unwrap();
 
         assert!(result.emitted);
         assert!(result.persist_warning.is_none());
@@ -869,13 +893,14 @@ mod tests {
         fs::write(root.join("snippets.md"), "## Echo\n\n```\necho hi\n```\n").unwrap();
         let paths = test_paths(&root);
         let mut writer = FailingWriter;
-        let err = run_execute_command_with(&paths, &mut writer, |_index, _store, _options| {
-            Ok(Some(ExecutionOutcome {
-                snippet_id: SnippetId::new("snippets.md", "echo"),
-                command: "echo hi".to_string(),
-            }))
-        })
-        .unwrap_err();
+        let err =
+            run_execute_command_with(&paths, &mut writer, None, |_index, _store, _options| {
+                Ok(Some(ExecutionOutcome {
+                    snippet_id: SnippetId::new("snippets.md", "echo"),
+                    command: "echo hi".to_string(),
+                }))
+            })
+            .unwrap_err();
         assert_eq!(err.to_string(), "nope");
         let saved = FrecencyStore::load(&paths.state_file).unwrap();
         assert!(saved.events().is_empty());

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -45,9 +45,14 @@ __pb_insert_command() {{
 }}
 bind -x '"{binding}":__pb_insert_command'
 __pb_complete() {{
-  local cur subcommand
+  local cur prev subcommand
   cur="${{COMP_WORDS[COMP_CWORD]}}"
+  prev="${{COMP_WORDS[COMP_CWORD-1]}}"
   subcommand="${{COMP_WORDS[1]}}"
+  if [[ "$prev" == "--theme" ]]; then
+    COMPREPLY=( $(compgen -W "$({executable} complete-theme "$cur")" -- "$cur") )
+    return 0
+  fi
   if [[ "$subcommand" == "edit" ]]; then
     COMPREPLY=()
     local candidate
@@ -56,7 +61,7 @@ __pb_complete() {{
     done < <({executable} complete-edit "$cur")
     return 0
   fi
-  COMPREPLY=( $(compgen -W "bash edit execute zsh fish" -- "$cur") )
+  COMPREPLY=( $(compgen -W "--theme bash edit execute zsh fish lint gc stats" -- "$cur") )
 }}
 complete -o nospace -F __pb_complete {BINARY_NAME} {BASH_ALIAS_NAME}
 "#
@@ -99,12 +104,16 @@ __pb_insert_command() {{
 zle -N __pb_insert_command
 bindkey "{binding}" __pb_insert_command
 _pb_complete() {{
-  if [[ "${{words[2]}}" == "edit" ]]; then
+  if [[ "${{words[CURRENT-1]}}" == "--theme" ]]; then
+    local -a candidates
+    candidates=( ${{(f)"$({executable} complete-theme "${{words[CURRENT]}}")"}} )
+    compadd -- "${{candidates[@]}}"
+  elif [[ "${{words[2]}}" == "edit" ]]; then
     local -a candidates
     candidates=( ${{(f)"$({executable} complete-edit "${{words[CURRENT]}}")"}} )
     compadd -S '' -- "${{candidates[@]}}"
   else
-    compadd -- bash edit execute zsh fish
+    compadd -- --theme bash edit execute zsh fish lint gc stats
   fi
 }}
 compdef _pb_complete {BINARY_NAME} {BASH_ALIAS_NAME}
@@ -139,9 +148,13 @@ end
 function __pb_complete_edit
   {executable} complete-edit (commandline -ct)
 end
+function __pb_complete_theme
+  {executable} complete-theme (commandline -ct)
+end
 bind {binding} __pb_insert_command
 alias {BASH_ALIAS_NAME}='{BINARY_NAME}'
-complete -c {BINARY_NAME} -f -n 'not __fish_seen_subcommand_from bash edit execute zsh fish' -a 'bash edit execute zsh fish'
+complete -c {BINARY_NAME} -f -l theme -a '(__pb_complete_theme)'
+complete -c {BINARY_NAME} -f -n 'not __fish_seen_subcommand_from bash edit execute zsh fish lint gc stats' -a 'bash edit execute zsh fish lint gc stats'
 complete -c {BINARY_NAME} -f -n '__fish_seen_subcommand_from edit' -a '(__pb_complete_edit)'
 complete -c {BASH_ALIAS_NAME} -w {BINARY_NAME}
 "#
@@ -210,6 +223,8 @@ mod tests {
     fn bash_script_completion_word_list_includes_all_shells() {
         let script = bash_integration_script("C+b", Path::new("/tmp/peanutbutter")).unwrap();
         assert!(script.contains("bash edit execute zsh fish"));
+        assert!(script.contains("complete-theme \"$cur\""));
+        assert!(script.contains("--theme"));
     }
 
     #[test]
@@ -239,6 +254,7 @@ mod tests {
         assert!(script.contains("\\builtin alias pb='peanutbutter'"));
         assert!(script.contains("compdef _pb_complete peanutbutter pb"));
         assert!(script.contains("'/tmp/peanutbutter' complete-edit"));
+        assert!(script.contains("'/tmp/peanutbutter' complete-theme"));
     }
 
     #[test]
@@ -270,6 +286,8 @@ mod tests {
         // complete-edit is called from a helper function to avoid single-quote nesting
         assert!(script.contains("__pb_complete_edit"));
         assert!(script.contains("'/tmp/peanutbutter' complete-edit"));
+        assert!(script.contains("__pb_complete_theme"));
+        assert!(script.contains("complete -c peanutbutter -f -l theme"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,8 +182,8 @@ impl Default for FrecencyConfig {
 pub type VariableInputConfig = crate::domain::VariableSpec;
 
 /// Visual theme: a set of ratatui [`Style`] values covering every distinct UI
-/// role. Build via [`Theme::default`] or [`Theme::from_raw`] (the TOML path).
-#[derive(Debug, Clone)]
+/// role. Build via [`Theme::default`] or one of the named constructors.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Theme {
     /// Muted style for decorative chrome (counters, separators, help text).
     pub chrome: Style,
@@ -233,52 +233,142 @@ impl Default for Theme {
 }
 
 impl Theme {
-    fn from_raw(raw: ThemeFileConfig) -> io::Result<Self> {
-        let mut theme = Theme::default();
-
-        if let Some(color) = raw.muted {
-            let color = parse_color(&color)?;
-            theme.chrome = theme.chrome.fg(color);
-            theme.placeholder = theme.placeholder.fg(color);
-        }
-
-        if let Some(color) = raw.accent {
-            let color = parse_color(&color)?;
-            theme.fuzzy_highlight = theme.fuzzy_highlight.fg(color);
-            theme.selected_marker = theme.selected_marker.fg(color);
-        }
-
-        if let Some(color) = raw.selected_bg {
-            let color = parse_color(&color)?;
-            theme.selected_marker = theme.selected_marker.bg(color);
-            theme.selected_item = theme.selected_item.bg(color);
-            theme.error = theme.error.bg(color);
-        }
-
-        if let Some(color) = raw.selected_fg {
-            theme.selected_item = theme.selected_item.fg(parse_color(&color)?);
-        }
-
-        if let Some(color) = raw.prompt_active_fg {
-            theme.active_prompt = theme.active_prompt.fg(parse_color(&color)?);
-        }
-
-        if let Some(color) = raw.prompt_active_bg {
-            theme.active_prompt = theme.active_prompt.bg(parse_color(&color)?);
-        }
-
-        if let Some(color) = raw.error_fg {
-            theme.error = theme.error.fg(parse_color(&color)?);
-        }
-
-        Ok(theme)
+    /// Return the stable names of themes built into the binary.
+    pub fn built_in_names() -> &'static [&'static str] {
+        &["default", "gruvbox", "catppuccin", "nord", "monochrome"]
     }
+
+    /// Build the named `gruvbox` theme.
+    pub fn gruvbox() -> Self {
+        Self::from_palette(ThemePalette {
+            accent: Color::Rgb(0xd7, 0x99, 0x21),
+            muted: Color::Rgb(0x8e, 0xc0, 0x7c),
+            selected_bg: Color::Rgb(0x3c, 0x38, 0x36),
+            selected_fg: Color::Rgb(0xfb, 0xf1, 0xc7),
+            prompt_fg: Color::Rgb(0x28, 0x28, 0x28),
+            prompt_bg: Color::Rgb(0xfa, 0xbd, 0x2f),
+            error_fg: Color::Rgb(0xfb, 0x49, 0x34),
+        })
+    }
+
+    /// Build the named `catppuccin` theme.
+    pub fn catppuccin() -> Self {
+        Self::from_palette(ThemePalette {
+            accent: Color::Rgb(0xf5, 0xc2, 0xe7),
+            muted: Color::Rgb(0x6c, 0x70, 0x86),
+            selected_bg: Color::Rgb(0x31, 0x34, 0x4a),
+            selected_fg: Color::Rgb(0xcd, 0xd6, 0xf4),
+            prompt_fg: Color::Rgb(0x1e, 0x1e, 0x2e),
+            prompt_bg: Color::Rgb(0x89, 0xb4, 0xfa),
+            error_fg: Color::Rgb(0xf3, 0x8b, 0xa8),
+        })
+    }
+
+    /// Build the named `nord` theme.
+    pub fn nord() -> Self {
+        Self::from_palette(ThemePalette {
+            accent: Color::Rgb(0x88, 0xc0, 0xd0),
+            muted: Color::Rgb(0x81, 0xa1, 0xc1),
+            selected_bg: Color::Rgb(0x3b, 0x42, 0x52),
+            selected_fg: Color::Rgb(0xec, 0xef, 0xf4),
+            prompt_fg: Color::Rgb(0x2e, 0x34, 0x40),
+            prompt_bg: Color::Rgb(0xa3, 0xbe, 0x8c),
+            error_fg: Color::Rgb(0xbf, 0x61, 0x6a),
+        })
+    }
+
+    /// Build the named `monochrome` theme with no foreground colours.
+    pub fn monochrome() -> Self {
+        Self {
+            chrome: Style::default().add_modifier(Modifier::DIM),
+            emphasis: Style::default().add_modifier(Modifier::BOLD),
+            fuzzy_highlight: Style::default().add_modifier(Modifier::BOLD),
+            selected_marker: Style::default().add_modifier(Modifier::REVERSED),
+            selected_item: Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED),
+            placeholder: Style::default().add_modifier(Modifier::DIM),
+            active_prompt: Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED),
+            divider: Style::default().add_modifier(Modifier::DIM),
+            border: Style::default().add_modifier(Modifier::DIM),
+            error: Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED),
+        }
+    }
+
+    fn named(name: &str) -> io::Result<Self> {
+        match name {
+            "default" => Ok(Theme::default()),
+            "gruvbox" => Ok(Theme::gruvbox()),
+            "catppuccin" => Ok(Theme::catppuccin()),
+            "nord" => Ok(Theme::nord()),
+            "monochrome" => Ok(Theme::monochrome()),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unknown theme {other}; expected one of: {}",
+                    Theme::built_in_names().join(", ")
+                ),
+            )),
+        }
+    }
+
+    fn from_palette(palette: ThemePalette) -> Self {
+        Self {
+            chrome: Style::default()
+                .fg(palette.muted)
+                .add_modifier(Modifier::DIM),
+            emphasis: Style::default().add_modifier(Modifier::BOLD),
+            fuzzy_highlight: Style::default()
+                .fg(palette.accent)
+                .add_modifier(Modifier::BOLD),
+            selected_marker: Style::default().fg(palette.accent).bg(palette.selected_bg),
+            selected_item: Style::default()
+                .fg(palette.selected_fg)
+                .bg(palette.selected_bg)
+                .add_modifier(Modifier::BOLD),
+            placeholder: Style::default()
+                .fg(palette.muted)
+                .add_modifier(Modifier::DIM),
+            active_prompt: Style::default()
+                .fg(palette.prompt_fg)
+                .bg(palette.prompt_bg)
+                .add_modifier(Modifier::BOLD),
+            divider: Style::default().fg(palette.muted),
+            border: Style::default().fg(palette.muted),
+            error: Style::default()
+                .fg(palette.error_fg)
+                .bg(palette.selected_bg),
+        }
+    }
+
+    fn from_raw(raw: &ThemeFileConfig, cli_theme: Option<&str>) -> io::Result<Self> {
+        if let Some(name) = cli_theme {
+            return raw.base_theme(name);
+        }
+
+        let name = raw.name.as_deref().unwrap_or("default");
+        let theme = raw.base_theme(name)?;
+        raw.colors.apply(theme)
+    }
+}
+
+struct ThemePalette {
+    accent: Color,
+    muted: Color,
+    selected_bg: Color,
+    selected_fg: Color,
+    prompt_fg: Color,
+    prompt_bg: Color,
+    error_fg: Color,
 }
 
 /// Load [`AppConfig`] from `$XDG_CONFIG_HOME/peanutbutter/config.toml` (or
 /// `$PB_CONFIG_FILE`). Missing files are silently treated as empty; parse
 /// errors are returned as `InvalidData` errors.
 pub fn load() -> io::Result<AppConfig> {
+    load_with_theme_override(None)
+}
+
+/// Load [`AppConfig`] and use `theme_name` as the theme base when provided.
+pub fn load_with_theme_override(theme_name: Option<&str>) -> io::Result<AppConfig> {
     let config_file = resolve_config_file();
     let file = load_file_config(&config_file)?;
     let paths = Paths {
@@ -313,9 +403,23 @@ pub fn load() -> io::Result<AppConfig> {
             },
         },
         variables: file.variables,
-        theme: Theme::from_raw(file.theme)?,
+        theme: Theme::from_raw(&file.theme, theme_name)?,
         lint: file.lint,
     })
+}
+
+/// Return names that shell completion should offer for the `--theme` flag.
+pub fn theme_completion_names() -> io::Result<Vec<String>> {
+    let config_file = resolve_config_file();
+    let file = load_file_config(&config_file)?;
+    let mut names = Theme::built_in_names()
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<Vec<_>>();
+    if file.theme.custom.is_some() {
+        names.push("custom".to_string());
+    }
+    Ok(names)
 }
 
 /// Return the resolved [`Paths`] from the config file, or compute defaults if
@@ -392,13 +496,113 @@ struct FrecencyFileConfig {
 
 #[derive(Debug, Default, Deserialize)]
 struct ThemeFileConfig {
+    name: Option<String>,
+    #[serde(flatten)]
+    colors: ThemeColorConfig,
+    custom: Option<ThemeColorConfig>,
+}
+
+impl ThemeFileConfig {
+    fn base_theme(&self, name: &str) -> io::Result<Theme> {
+        if name == "custom" {
+            let Some(custom) = &self.custom else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "theme name 'custom' requires a [theme.custom] block",
+                ));
+            };
+            return custom.to_theme();
+        }
+        Theme::named(name)
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ThemeColorConfig {
     accent: Option<String>,
     muted: Option<String>,
     selected_bg: Option<String>,
     selected_fg: Option<String>,
     prompt_active_fg: Option<String>,
     prompt_active_bg: Option<String>,
+    prompt_fg: Option<String>,
+    prompt_bg: Option<String>,
     error_fg: Option<String>,
+}
+
+impl ThemeColorConfig {
+    fn apply(&self, mut theme: Theme) -> io::Result<Theme> {
+        if let Some(color) = &self.muted {
+            let color = parse_color(color)?;
+            theme.chrome = theme.chrome.fg(color);
+            theme.placeholder = theme.placeholder.fg(color);
+        }
+
+        if let Some(color) = &self.accent {
+            let color = parse_color(color)?;
+            theme.fuzzy_highlight = theme.fuzzy_highlight.fg(color);
+            theme.selected_marker = theme.selected_marker.fg(color);
+        }
+
+        if let Some(color) = &self.selected_bg {
+            let color = parse_color(color)?;
+            theme.selected_marker = theme.selected_marker.bg(color);
+            theme.selected_item = theme.selected_item.bg(color);
+            theme.error = theme.error.bg(color);
+        }
+
+        if let Some(color) = &self.selected_fg {
+            theme.selected_item = theme.selected_item.fg(parse_color(color)?);
+        }
+
+        if let Some(color) = self.prompt_fg() {
+            theme.active_prompt = theme.active_prompt.fg(parse_color(color)?);
+        }
+
+        if let Some(color) = self.prompt_bg() {
+            theme.active_prompt = theme.active_prompt.bg(parse_color(color)?);
+        }
+
+        if let Some(color) = &self.error_fg {
+            theme.error = theme.error.fg(parse_color(color)?);
+        }
+
+        Ok(theme)
+    }
+
+    fn to_theme(&self) -> io::Result<Theme> {
+        Ok(Theme::from_palette(ThemePalette {
+            accent: self.required_color("accent", &self.accent)?,
+            muted: self.required_color("muted", &self.muted)?,
+            selected_bg: self.required_color("selected_bg", &self.selected_bg)?,
+            selected_fg: self.required_color("selected_fg", &self.selected_fg)?,
+            prompt_fg: self.required_color("prompt_fg", &self.prompt_fg().map(str::to_string))?,
+            prompt_bg: self.required_color("prompt_bg", &self.prompt_bg().map(str::to_string))?,
+            error_fg: self.required_color("error_fg", &self.error_fg)?,
+        }))
+    }
+
+    fn prompt_fg(&self) -> Option<&str> {
+        self.prompt_fg
+            .as_deref()
+            .or(self.prompt_active_fg.as_deref())
+    }
+
+    fn prompt_bg(&self) -> Option<&str> {
+        self.prompt_bg
+            .as_deref()
+            .or(self.prompt_active_bg.as_deref())
+    }
+
+    fn required_color(&self, name: &str, value: &Option<String>) -> io::Result<Color> {
+        let value = value.as_deref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("custom theme missing required color {name}"),
+            )
+        })?;
+        parse_color(value)
+    }
 }
 
 fn string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
@@ -552,20 +756,78 @@ mod tests {
 
     #[test]
     fn theme_accepts_named_and_hex_colors() {
-        let theme = Theme::from_raw(ThemeFileConfig {
-            accent: Some("#112233".to_string()),
-            muted: Some("dark_gray".to_string()),
-            selected_bg: Some("blue".to_string()),
-            selected_fg: Some("white".to_string()),
-            prompt_active_fg: Some("yellow".to_string()),
-            prompt_active_bg: Some("#445566".to_string()),
-            error_fg: Some("red".to_string()),
-        })
+        let theme = Theme::from_raw(
+            &ThemeFileConfig {
+                colors: ThemeColorConfig {
+                    accent: Some("#112233".to_string()),
+                    muted: Some("dark_gray".to_string()),
+                    selected_bg: Some("blue".to_string()),
+                    selected_fg: Some("white".to_string()),
+                    prompt_active_fg: Some("yellow".to_string()),
+                    prompt_active_bg: Some("#445566".to_string()),
+                    error_fg: Some("red".to_string()),
+                    ..ThemeColorConfig::default()
+                },
+                ..ThemeFileConfig::default()
+            },
+            None,
+        )
         .unwrap();
 
         assert_eq!(theme.selected_marker.fg, Some(Color::Rgb(0x11, 0x22, 0x33)));
         assert_eq!(theme.selected_item.bg, Some(Color::Blue));
         assert_eq!(theme.active_prompt.bg, Some(Color::Rgb(0x44, 0x55, 0x66)));
+    }
+
+    #[test]
+    fn theme_name_selects_builtin_and_cli_skips_overrides() {
+        let raw = ThemeFileConfig {
+            name: Some("gruvbox".to_string()),
+            colors: ThemeColorConfig {
+                accent: Some("red".to_string()),
+                ..ThemeColorConfig::default()
+            },
+            ..ThemeFileConfig::default()
+        };
+
+        let config_theme = Theme::from_raw(&raw, None).unwrap();
+        let cli_theme = Theme::from_raw(&raw, Some("nord")).unwrap();
+
+        assert_eq!(config_theme.selected_marker.fg, Some(Color::Red));
+        assert_eq!(cli_theme, Theme::nord());
+    }
+
+    #[test]
+    fn custom_theme_requires_complete_custom_block() {
+        let raw = r##"
+[theme]
+name = "custom"
+accent = "red"
+
+[theme.custom]
+accent = "#c678dd"
+muted = "#5c6370"
+selected_bg = "#3e4451"
+selected_fg = "#abb2bf"
+prompt_fg = "#282c34"
+prompt_bg = "#61afef"
+error_fg = "#e06c75"
+"##;
+        let parsed: FileConfig = toml::from_str(raw).unwrap();
+        let theme = Theme::from_raw(&parsed.theme, None).unwrap();
+
+        assert_eq!(theme.selected_marker.fg, Some(Color::Red));
+        assert_eq!(theme.active_prompt.bg, Some(Color::Rgb(0x61, 0xaf, 0xef)));
+    }
+
+    #[test]
+    fn unknown_theme_name_is_clear_error() {
+        let raw = ThemeFileConfig {
+            name: Some("wat".to_string()),
+            ..ThemeFileConfig::default()
+        };
+        let err = Theme::from_raw(&raw, None).unwrap_err();
+        assert!(err.to_string().contains("unknown theme wat"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,22 @@ use peanutbutter::completions;
 use peanutbutter::config;
 use std::io::{self, Write};
 
+fn raw_theme_arg() -> Option<String> {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--theme" {
+            return args.next();
+        }
+        if let Some(value) = arg.strip_prefix("--theme=") {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
 fn main() {
-    let app_config = match config::load() {
+    let raw_theme = raw_theme_arg();
+    let app_config = match config::load_with_theme_override(raw_theme.as_deref()) {
         Ok(config) => config,
         Err(err) => {
             eprintln!("{BINARY_NAME}: {err}");
@@ -22,20 +36,25 @@ fn main() {
     let mut clap_command = cli::Cli::command().after_help(cli::after_help(&paths));
     let matches = clap_command.clone().get_matches();
     let cli = cli::Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
-    let Some(command) = cli.command else {
-        clap_command.print_help().unwrap_or_else(|err| {
-            eprintln!("{BINARY_NAME}: {err}");
-            std::process::exit(1);
-        });
-        println!();
-        std::process::exit(0);
+    let theme_name = cli.theme.as_deref();
+    let command = match cli.command {
+        Some(command) => command,
+        None if theme_name.is_some() => cli::Command::Execute,
+        None => {
+            clap_command.print_help().unwrap_or_else(|err| {
+                eprintln!("{BINARY_NAME}: {err}");
+                std::process::exit(1);
+            });
+            println!();
+            std::process::exit(0);
+        }
     };
     let is_execute = matches!(&command, cli::Command::Execute);
 
     let result = match command {
         cli::Command::Execute => {
             let mut stdout = io::stdout();
-            let result = cli::run_execute_command(&paths, &mut stdout);
+            let result = cli::run_execute_command(&paths, &mut stdout, theme_name);
             let _ = stdout.flush();
             match result {
                 Ok(result) => {
@@ -135,6 +154,18 @@ fn main() {
                 Err(err) => Err(err),
             }
         }
+        cli::Command::CompleteTheme { current } => match config::theme_completion_names() {
+            Ok(candidates) => {
+                let current = current.unwrap_or_default();
+                for candidate in candidates {
+                    if candidate.starts_with(&current) {
+                        println!("{candidate}");
+                    }
+                }
+                Ok(())
+            }
+            Err(err) => Err(err),
+        },
     };
 
     if let Err(err) = result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 use clap::{CommandFactory, FromArgMatches};
+use owo_colors::OwoColorize;
 use peanutbutter::BINARY_NAME;
 use peanutbutter::cli;
 use peanutbutter::completions;
 use peanutbutter::config;
-use std::io::{self, Write};
+use std::fmt;
+use std::io::{self, IsTerminal, Write};
 
 fn raw_theme_arg() -> Option<String> {
     let mut args = std::env::args().skip(1);
@@ -18,12 +20,36 @@ fn raw_theme_arg() -> Option<String> {
     None
 }
 
+fn format_error_message(message: &str, color: bool) -> String {
+    if !color {
+        return message.to_string();
+    }
+
+    let Some((prefix, names)) = message.split_once("expected one of: ") else {
+        return message.to_string();
+    };
+    let names = names
+        .split(", ")
+        .map(|name| name.bold().cyan().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{prefix}expected one of: {names}")
+}
+
+fn print_error(err: impl fmt::Display) {
+    let color = std::env::var_os("NO_COLOR").is_none() && io::stderr().is_terminal();
+    eprintln!(
+        "{BINARY_NAME}: {}",
+        format_error_message(&err.to_string(), color)
+    );
+}
+
 fn main() {
     let raw_theme = raw_theme_arg();
     let app_config = match config::load_with_theme_override(raw_theme.as_deref()) {
         Ok(config) => config,
         Err(err) => {
-            eprintln!("{BINARY_NAME}: {err}");
+            print_error(err);
             let code = if std::env::args().any(|arg| arg == "lint") {
                 2
             } else {
@@ -42,7 +68,7 @@ fn main() {
         None if theme_name.is_some() => cli::Command::Execute,
         None => {
             clap_command.print_help().unwrap_or_else(|err| {
-                eprintln!("{BINARY_NAME}: {err}");
+                print_error(err);
                 std::process::exit(1);
             });
             println!();
@@ -109,7 +135,7 @@ fn main() {
                     Ok(())
                 }
                 Err(err) => {
-                    eprintln!("{BINARY_NAME}: {err}");
+                    print_error(err);
                     std::process::exit(2);
                 }
             }
@@ -169,10 +195,28 @@ fn main() {
     };
 
     if let Err(err) = result {
-        eprintln!("{BINARY_NAME}: {err}");
+        print_error(err);
         if is_execute {
             eprintln!("{BINARY_NAME}: execute failed");
         }
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_error_message_colours_theme_names_only_when_enabled() {
+        let raw = "unknown theme invalid; expected one of: default, gruvbox";
+
+        assert_eq!(format_error_message(raw, false), raw);
+        let colored = format_error_message(raw, true);
+
+        assert!(colored.contains("unknown theme invalid; expected one of: "));
+        assert!(colored.contains("\u{1b}["));
+        assert!(colored.contains("default"));
+        assert!(colored.contains("gruvbox"));
     }
 }


### PR DESCRIPTION
## Why

Theming currently only allows per-color overrides, so users cannot switch between complete palettes or share a full custom look. Issue #21 asks for named built-in themes, config/CLI selection, custom themes, and shell completion support.

## What

- Add built-in `default`, `gruvbox`, `catppuccin`, `nord`, and `monochrome` theme constructors.
- Add `[theme] name = "..."` resolution, with top-level color overrides applied on config-selected bases.
- Add global `--theme <name>` support for `peanutbutter --theme ...` and `peanutbutter execute --theme ...`; CLI-selected named themes skip config color overrides.
- Support inline custom themes via `name = "custom"` and `[theme.custom]` with required base colors.
- Add hidden `complete-theme` plus bash/zsh/fish `--theme` completion wiring.
- Highlight available theme names in stderr theme-name errors when stderr is a TTY and `NO_COLOR` is not set.
- Document theme selection and custom theme examples in README / `examples/config.toml`.

## Verification

- `cargo fmt --check`
- `cargo test` (202 unit tests + 11 integration tests pass)
- `cargo clippy -- -D warnings`
- `cargo build`
- Manual: `./target/debug/peanutbutter complete-theme ""` lists built-ins.
- Manual: unknown config theme exits with a clear `unknown theme wat; expected one of: ...` error.
- Manual: config-defined `[theme.custom]` adds `custom` to theme completion.
- Manual: `--theme` accepts every built-in name via `complete-theme`.
- Targeted: `cargo test format_error_message_colours_theme_names_only_when_enabled`.
- Pre-commit and pre-push hooks passed.

## Review focus

- User-defined theme support is intentionally the inline `[theme.custom]` path from the issue, not a separate theme directory.
- The hidden `complete-theme` command lists built-ins and `custom` when present in config; there is no broader user theme discovery yet.

Closes #21

