### PR TITLE
feat(tui): esc climbs browse path before exiting

### DIFF
--- a/src/execute/app.rs
+++ b/src/execute/app.rs
@@ -499,11 +499,23 @@ impl<P: SuggestionProvider> ExecutionApp<P> {
     }
 
     fn handle_select_key(&mut self, key: KeyEvent) -> AppEvent {
-        if matches!(key.code, KeyCode::Esc)
-            && !(matches!(self.nav_mode, NavigationMode::Tags) && self.tags.drill.is_some())
-        {
-            self.status = Some("cancelled".to_string());
-            return AppEvent::Cancelled;
+        if matches!(key.code, KeyCode::Esc) {
+            // Tag-drill handles esc in its own key handler (climbs out of drill).
+            if matches!(self.nav_mode, NavigationMode::Tags) && self.tags.drill.is_some() {
+                // fall through to mode-specific handler
+            } else if matches!(self.nav_mode, NavigationMode::Browse)
+                && !self.browse.path.is_empty()
+            {
+                self.browse.path.pop();
+                self.browse.input.clear();
+                self.browse.selection = Some(0);
+                self.preview_scroll = 0;
+                self.status = None;
+                return AppEvent::Continue;
+            } else {
+                self.status = Some("cancelled".to_string());
+                return AppEvent::Cancelled;
+            }
         }
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('t')

--- a/src/execute/tests.rs
+++ b/src/execute/tests.rs
@@ -333,6 +333,32 @@ fn ctrl_e_from_browse_requests_edit_for_selected_snippet() {
 }
 
 #[test]
+fn esc_in_browse_climbs_path_when_nested() {
+    let mut app = app_with_body("echo hi", vec![], TestProvider::default());
+    app.nav_mode = NavigationMode::Browse;
+    app.browse.path = vec!["git".to_string(), "commits.md".to_string()];
+    app.browse.input = "foo".to_string();
+    app.browse.selection = Some(2);
+
+    let event = app.handle_key(press(KeyCode::Esc));
+
+    assert!(matches!(event, AppEvent::Continue));
+    assert_eq!(app.browse.path, vec!["git".to_string()]);
+    assert_eq!(app.browse.input, "");
+    assert_eq!(app.browse.selection, Some(0));
+}
+
+#[test]
+fn esc_in_browse_at_root_cancels() {
+    let mut app = app_with_body("echo hi", vec![], TestProvider::default());
+    app.nav_mode = NavigationMode::Browse;
+    app.browse.path = Vec::new();
+
+    let event = app.handle_key(press(KeyCode::Esc));
+    assert!(matches!(event, AppEvent::Cancelled));
+}
+
+#[test]
 fn ctrl_e_from_browse_directory_does_not_request_edit() {
     let mut app = app_with_body("echo hi", vec![], TestProvider::default());
     app.nav_mode = NavigationMode::Browse;


### PR DESCRIPTION
## Summary

- In browse mode, Esc now pops one path segment (and clears the filter input) when nested
- Esc only exits the TUI when already at the browse root
- Tag-drill Esc behavior is unchanged

## Test plan

- [x] `esc_in_browse_climbs_path_when_nested`
- [x] `esc_in_browse_at_root_cancels`
- [x] full `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`