### PR TITLE
feat: add PowerShell Windows support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,17 @@ jobs:
     permissions:
       contents: write
     needs: [ci, release_notes]
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
-          - target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -67,15 +71,43 @@ jobs:
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Test Windows target
+        if: runner.os == 'Windows'
+        run: cargo test --target ${{ matrix.target }}
       - name: Build release
         run: cargo build --release --target ${{ matrix.target }}
-      - name: Package release artifact
+      - name: Package Unix release artifact
+        if: runner.os != 'Windows'
         run: |
           mkdir -p dist
           tar -czf "dist/${{ env.BINARY_NAME }}-${{ matrix.target }}.tar.gz" \
             -C "target/${{ matrix.target }}/release" "${{ env.BINARY_NAME }}"
+      - name: Package Windows release artifact
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force dist | Out-Null
+          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe" -DestinationPath "dist/${{ env.BINARY_NAME }}-${{ matrix.target }}.zip"
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish_release:
+    permissions:
+      contents: write
+    needs: [release, release_notes]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/${{ env.BINARY_NAME }}-${{ matrix.target }}.tar.gz
+          files: dist/*
           body: ${{ needs.release_notes.outputs.body }}

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -28,16 +28,18 @@ jobs:
         run: cargo test
 
   release:
-    permissions:
-      contents: write
     needs: ci
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
-          - target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -49,13 +51,41 @@ jobs:
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Test Windows target
+        if: runner.os == 'Windows'
+        run: cargo test --target ${{ matrix.target }}
       - name: Build release
         run: cargo build --release --target ${{ matrix.target }}
-      - name: Package release artifact
+      - name: Package Unix release artifact
+        if: runner.os != 'Windows'
         run: |
           mkdir -p dist
           tar -czf "dist/${{ env.BINARY_NAME }}-${{ matrix.target }}.tar.gz" \
             -C "target/${{ matrix.target }}/release" "${{ env.BINARY_NAME }}"
+      - name: Package Windows release artifact
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force dist | Out-Null
+          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe" -DestinationPath "dist/${{ env.BINARY_NAME }}-${{ matrix.target }}.zip"
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish_unstable:
+    permissions:
+      contents: write
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
       - name: Update unstable release
         uses: softprops/action-gh-release@v2
         with:
@@ -63,7 +93,7 @@ jobs:
           name: "Unstable (main)"
           prerelease: true
           make_latest: false
-          files: dist/${{ env.BINARY_NAME }}-${{ matrix.target }}.tar.gz
+          files: dist/*
           body: |
             Automated build from `main` at ${{ github.sha }}.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,6 @@ dependencies = [
  "ansi-to-tui",
  "clap",
  "crossterm 0.28.1",
- "libc",
  "nucleo-matcher",
  "owo-colors",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 ansi-to-tui = "8.0"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.28"
-libc = "0.2"
 nucleo-matcher = "0.3"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ set -x PEANUTBUTTER_PATH "$PWD/examples"
 peanutbutter fish | source
 ```
 
+**PowerShell** — add to `$PROFILE`:
+
+```powershell
+$env:PEANUTBUTTER_PATH = "$PWD/examples"
+peanutbutter powershell | Invoke-Expression
+```
+
 ## Why
 
 I personally find that other cheatsheet or snippet tools don't adapt to my workflows, and cause me to constantly exit out of my own flow state.
@@ -81,7 +88,7 @@ $ pb new deploy
 space toggle   e rename   n name   enter accept   b back   esc cancel
 ```
 
-`pb new` requires the shell integration to be sourced (`eval "$(peanutbutter bash C+b)"` or its zsh/fish equivalent) — that's what populates the history list. You can skip the history step entirely by passing a command after `--`:
+`pb new` requires the shell integration to be sourced (`eval "$(peanutbutter bash C+b)"` or its zsh/fish/PowerShell equivalent) — that's what populates the history list. You can skip the history step entirely by passing a command after `--`:
 
 ```bash
 pb new deploy -- ssh root@host 'systemctl restart nginx'
@@ -185,11 +192,12 @@ disable = false
 1. `peanutbutter bash [C+b]` — emit bash integration script (eval it in `~/.bashrc`)
 2. `peanutbutter zsh [C+b]` — emit zsh integration script (eval it in `~/.zshrc`)
 3. `peanutbutter fish [C+b]` — emit fish integration script (source it in `config.fish`)
-4. `peanutbutter edit ...` — edit a snippet file in `$EDITOR`/`$VISUAL`
-5. `peanutbutter lint [--strict] [--json]` — check configured snippet roots for authoring problems
-6. `peanutbutter execute [--theme <name>]` — run the inline TUI; output can be piped, e.g. `peanutbutter execute | grep foo`
+4. `peanutbutter powershell [C+b]` — emit PowerShell/PSReadLine integration script (add it to `$PROFILE`)
+5. `peanutbutter edit ...` — edit a snippet file in `$EDITOR`/`$VISUAL`
+6. `peanutbutter lint [--strict] [--json]` — check configured snippet roots for authoring problems
+7. `peanutbutter execute [--theme <name>]` — run the inline TUI; output can be piped, e.g. `peanutbutter execute | grep foo`
 
-All three shell integrations install a `pb` alias and wire up `pb edit <TAB>` plus `--theme <TAB>` completion.
+All shell integrations install a `pb` alias and wire up `pb edit <TAB>` plus `--theme <TAB>` completion.
 
 `pb lint` is read-only. It reports broken frontmatter, unused frontmatter/config variables, duplicate snippet slugs, suggestion-command failures, dry-run frecency GC orphans, and obvious static inline suggestion commands. Bare manual placeholders like `<@value>` are valid in normal mode. `--strict` adds style/structure checks such as undeclared manual placeholders, unbalanced fences, missing code-fence language tags, and confusing file-local variable overrides. Pretty output is written to stdout by default; `--json` writes a parseable object with stable `findings[].code` fields. Exit codes are `0` for no findings, `1` for lint findings, and `2` for operational failures that prevent lint from running.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,11 @@ pub enum Command {
         #[arg(default_value = "C+b")]
         binding: String,
     },
+    /// Emit PowerShell integration code for the given PSReadLine binding.
+    Powershell {
+        #[arg(default_value = "C+b")]
+        binding: String,
+    },
     /// Check snippet files for authoring problems.
     Lint {
         /// Include stricter style and structure checks.
@@ -115,7 +120,7 @@ pub struct ExecuteCommandResult {
 pub fn after_help(paths: &Paths) -> String {
     let mut out = String::new();
     out.push_str(&format!(
-        "shell integration: `{BINARY_NAME} bash|zsh|fish` also defines `{BASH_ALIAS_NAME}`\n\n"
+        "shell integration: `{BINARY_NAME} bash|zsh|fish|powershell` also defines `{BASH_ALIAS_NAME}`\n\n"
     ));
     out.push_str("snippet roots:\n");
     for root in &paths.snippet_roots {
@@ -843,6 +848,14 @@ mod tests {
             })
         );
         assert_eq!(
+            Cli::try_parse_from(["peanutbutter", "powershell"])
+                .unwrap()
+                .command,
+            Some(Command::Powershell {
+                binding: "C+b".to_string()
+            })
+        );
+        assert_eq!(
             Cli::try_parse_from(["peanutbutter", "complete-edit", "nested/"])
                 .unwrap()
                 .command,
@@ -893,7 +906,7 @@ mod tests {
     fn after_help_mentions_all_shells_and_pb_alias() {
         let paths = test_paths(Path::new("/tmp/snippets"));
         let help = after_help(&paths);
-        assert!(help.contains("bash|zsh|fish` also defines `pb`"));
+        assert!(help.contains("bash|zsh|fish|powershell` also defines `pb`"));
         assert!(help.contains("snippet roots:"));
         assert!(help.contains("/tmp/snippets"));
     }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,7 +1,7 @@
-//! Shell integration scripts for bash, zsh, and fish.
+//! Shell integration scripts for bash, zsh, fish, and PowerShell.
 //!
-//! Each public function emits a shell script intended to be eval'd (bash/zsh)
-//! or sourced (fish) from the user's shell init file. The script installs a
+//! Each public function emits a shell script intended to be eval'd (bash/zsh),
+//! sourced (fish), or added to the user's PowerShell profile. The script installs a
 //! key binding that runs the peanutbutter TUI and injects the selected command
 //! into the shell's readline buffer, plus tab-completion for `peanutbutter edit`.
 
@@ -71,7 +71,7 @@ __pb_complete() {{
     done < <({executable} complete-edit "$cur")
     return 0
   fi
-  COMPREPLY=( $(compgen -W "--theme bash edit execute zsh fish lint gc new stats" -- "$cur") )
+  COMPREPLY=( $(compgen -W "--theme bash edit execute zsh fish powershell lint gc new stats" -- "$cur") )
 }}
 complete -o nospace -F __pb_complete {BINARY_NAME} {BASH_ALIAS_NAME}
 "#
@@ -133,7 +133,7 @@ _pb_complete() {{
     candidates=( ${{(f)"$({executable} complete-edit "${{words[CURRENT]}}")"}} )
     compadd -S '' -- "${{candidates[@]}}"
   else
-    compadd -- --theme bash edit execute zsh fish lint gc new stats
+    compadd -- --theme bash edit execute zsh fish powershell lint gc new stats
   fi
 }}
 compdef _pb_complete {BINARY_NAME} {BASH_ALIAS_NAME}
@@ -188,9 +188,59 @@ function {BINARY_NAME}
   __pb_dispatch $argv
 end
 complete -c {BINARY_NAME} -f -l theme -a '(__pb_complete_theme)'
-complete -c {BINARY_NAME} -f -n 'not __fish_seen_subcommand_from bash edit execute zsh fish lint gc new stats' -a 'bash edit execute zsh fish lint gc new stats'
+complete -c {BINARY_NAME} -f -n 'not __fish_seen_subcommand_from bash edit execute zsh fish powershell lint gc new stats' -a 'bash edit execute zsh fish powershell lint gc new stats'
 complete -c {BINARY_NAME} -f -n '__fish_seen_subcommand_from edit' -a '(__pb_complete_edit)'
 complete -c {BASH_ALIAS_NAME} -w {BINARY_NAME}
+"#
+    ))
+}
+
+/// Emit the PowerShell integration script using the path of the currently running
+/// executable. Intended for `peanutbutter powershell`; the caller should add the
+/// output to their PowerShell profile.
+pub fn powershell_integration_for_current_exe(binding: &str) -> io::Result<String> {
+    let exe = env::current_exe()?;
+    powershell_integration_script(binding, &exe)
+}
+
+/// Build the PowerShell integration script for a given `executable` path and
+/// PSReadLine `binding` (e.g. `"C+b"`). Separated from
+/// [`powershell_integration_for_current_exe`] so tests can supply a controlled path.
+pub fn powershell_integration_script(binding: &str, executable: &Path) -> io::Result<String> {
+    let binding = powershell_binding(binding)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let executable = powershell_quote(&executable.to_string_lossy());
+    Ok(format!(
+        r#"$script:__pb_exe = {executable}
+function __pb_dispatch {{
+  if ($args.Count -gt 0 -and $args[0] -eq 'new') {{
+    $oldHistory = $env:PEANUTBUTTER_HISTORY
+    $env:PEANUTBUTTER_HISTORY = (Get-History -Count 50 | Sort-Object Id -Descending | ForEach-Object CommandLine | Where-Object {{ $_ -notmatch '^\s*(pb|peanutbutter)(\s|$)' }} | Select-Object -First 50) -join [char]31
+    try {{ & $script:__pb_exe @args }} finally {{
+      if ($null -eq $oldHistory) {{ Remove-Item Env:\PEANUTBUTTER_HISTORY -ErrorAction SilentlyContinue }} else {{ $env:PEANUTBUTTER_HISTORY = $oldHistory }}
+    }}
+  }} else {{
+    & $script:__pb_exe @args
+  }}
+}}
+function {BASH_ALIAS_NAME} {{ __pb_dispatch @args }}
+function {BINARY_NAME} {{ __pb_dispatch @args }}
+Set-PSReadLineKeyHandler -Chord '{binding}' -ScriptBlock {{
+  $cmd = (& $script:__pb_exe execute) -join [Environment]::NewLine
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($cmd)) {{ return }}
+  [Microsoft.PowerShell.PSConsoleReadLine]::Insert($cmd)
+}}
+Register-ArgumentCompleter -CommandName {BINARY_NAME},{BASH_ALIAS_NAME} -ScriptBlock {{
+  param($wordToComplete, $commandAst, $cursorPosition)
+  $words = @($commandAst.CommandElements | ForEach-Object {{ $_.Extent.Text }})
+  if ($words.Count -ge 2 -and ($words[$words.Count - 1] -eq '--theme' -or $words[$words.Count - 2] -eq '--theme')) {{
+    & $script:__pb_exe complete-theme $wordToComplete | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
+  }} elseif ($words.Count -ge 2 -and $words[1] -eq 'edit') {{
+    & $script:__pb_exe complete-edit $wordToComplete | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
+  }} else {{
+    'bash','edit','execute','zsh','fish','powershell','lint','gc','new','stats','--theme' | Where-Object {{ $_ -like "$wordToComplete*" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
+  }}
+}}
 "#
     ))
 }
@@ -223,6 +273,14 @@ fn zsh_bindkey_binding(binding: &str) -> Result<String, String> {
 
 fn fish_bind_key(binding: &str) -> Result<String, String> {
     parse_ctrl_key(binding).map(|ch| format!("\\c{}", ch.to_ascii_lowercase()))
+}
+
+fn powershell_binding(binding: &str) -> Result<String, String> {
+    parse_ctrl_key(binding).map(|ch| format!("Ctrl+{}", ch.to_ascii_lowercase()))
+}
+
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 fn shell_quote(value: &str) -> String {
@@ -259,7 +317,7 @@ mod tests {
     #[test]
     fn bash_script_completion_word_list_includes_all_shells() {
         let script = bash_integration_script("C+b", Path::new("/tmp/peanutbutter")).unwrap();
-        assert!(script.contains("bash edit execute zsh fish lint gc new stats"));
+        assert!(script.contains("bash edit execute zsh fish powershell lint gc new stats"));
         assert!(script.contains("complete-theme \"$cur\""));
         assert!(script.contains("--theme"));
     }
@@ -373,5 +431,39 @@ mod tests {
     #[test]
     fn fish_script_rejects_invalid_binding() {
         assert!(fish_integration_script("notabinding", Path::new("/tmp/pb")).is_err());
+    }
+
+    #[test]
+    fn powershell_script_registers_psreadline_insert_handler() {
+        let script =
+            powershell_integration_script("C+b", Path::new("C:/Tools/peanutbutter.exe")).unwrap();
+        assert!(script.contains("Set-PSReadLineKeyHandler -Chord 'Ctrl+b'"));
+        assert!(script.contains("[Microsoft.PowerShell.PSConsoleReadLine]::Insert($cmd)"));
+        assert!(script.contains("(& $script:__pb_exe execute) -join [Environment]::NewLine"));
+        assert!(script.contains("$script:__pb_exe = 'C:/Tools/peanutbutter.exe'"));
+    }
+
+    #[test]
+    fn powershell_script_emits_pb_alias_history_and_completions() {
+        let script = powershell_integration_script("C+b", Path::new("C:/pb.exe")).unwrap();
+        assert!(script.contains("function pb { __pb_dispatch @args }"));
+        assert!(script.contains("function peanutbutter { __pb_dispatch @args }"));
+        assert!(script.contains("Get-History -Count 50"));
+        assert!(script.contains("PEANUTBUTTER_HISTORY"));
+        assert!(script.contains("Register-ArgumentCompleter -CommandName peanutbutter,pb"));
+        assert!(script.contains("complete-edit $wordToComplete"));
+        assert!(script.contains("complete-theme $wordToComplete"));
+        assert!(script.contains("'powershell'"));
+    }
+
+    #[test]
+    fn powershell_script_uses_requested_binding() {
+        let script = powershell_integration_script("C+f", Path::new("C:/pb.exe")).unwrap();
+        assert!(script.contains("Set-PSReadLineKeyHandler -Chord 'Ctrl+f'"));
+    }
+
+    #[test]
+    fn powershell_script_rejects_invalid_binding() {
+        assert!(powershell_integration_script("notabinding", Path::new("C:/pb.exe")).is_err());
     }
 }

--- a/src/execute/terminal.rs
+++ b/src/execute/terminal.rs
@@ -10,11 +10,9 @@ use crossterm::execute;
 use crossterm::terminal::{self, ClearType, disable_raw_mode, enable_raw_mode};
 use ratatui::backend::CrosstermBackend;
 use ratatui::{Terminal, TerminalOptions, Viewport};
-use std::fs;
 use std::io;
 use std::io::IsTerminal;
 use std::io::Write;
-use std::os::fd::{FromRawFd, OwnedFd};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::app::{AppEvent, ExecutionApp, SuggestionProvider, SystemSuggestionProvider};
@@ -57,8 +55,8 @@ pub fn run_execute(
 /// Core TUI runner — sets up the terminal, runs the event loop, tears down.
 ///
 /// Steps:
-/// 1. Redirect stdout to the TTY if it was piped (needed so the shell can
-///    capture the emitted command while we still draw to the terminal).
+/// 1. Choose stdout or stderr for TUI drawing. Shell integrations capture stdout
+///    for the emitted command, so stderr is used when stdout is piped.
 /// 2. Enter raw mode via [`RawModeGuard`].
 /// 3. Build a ratatui inline viewport and enter the draw/poll loop.
 /// 4. On exit, drain any buffered key-release events (kitty keyboard protocol)
@@ -81,9 +79,9 @@ pub fn run_execute_with_provider<P: SuggestionProvider>(
         options.theme,
         provider,
     );
-    let _stdout_guard = StdoutTtyGuard::enter()?;
-    let mut raw_mode = RawModeGuard::enter()?;
-    let mut terminal = build_terminal(options.viewport_height)?;
+    let tui_output = TuiOutputKind::detect();
+    let mut raw_mode = RawModeGuard::enter(tui_output)?;
+    let mut terminal = build_terminal(options.viewport_height, tui_output)?;
     let mut viewport_top: Option<u16> = None;
     let outcome = loop {
         terminal.draw(|frame| {
@@ -113,11 +111,11 @@ pub fn run_execute_with_provider<P: SuggestionProvider>(
                     ));
                     continue;
                 };
-                cleanup_terminal(viewport_top)?;
+                cleanup_terminal(viewport_top, tui_output)?;
                 raw_mode.suspend()?;
                 let edit_result = edit_snippet(&snippet);
                 raw_mode.resume()?;
-                terminal = build_terminal(options.viewport_height)?;
+                terminal = build_terminal(options.viewport_height, tui_output)?;
                 viewport_top = None;
                 app.status = Some(edit_status(edit_result, &mut app, &options.snippet_roots));
             }
@@ -130,13 +128,16 @@ pub fn run_execute_with_provider<P: SuggestionProvider>(
     while event::poll(Duration::ZERO).unwrap_or(false) {
         let _ = event::read();
     }
-    cleanup_terminal(viewport_top)?;
+    cleanup_terminal(viewport_top, tui_output)?;
     Ok(outcome)
 }
 
-fn build_terminal(viewport_height: u16) -> io::Result<Terminal<CrosstermBackend<io::Stdout>>> {
-    let backend = CrosstermBackend::new(io::stdout());
-    let viewport_height = inline_viewport_height(viewport_height)?;
+fn build_terminal(
+    viewport_height: u16,
+    output: TuiOutputKind,
+) -> io::Result<Terminal<CrosstermBackend<TuiOutput>>> {
+    let backend = CrosstermBackend::new(output.writer());
+    let viewport_height = inline_viewport_height(viewport_height);
     match Terminal::with_options(
         backend,
         TerminalOptions {
@@ -144,13 +145,12 @@ fn build_terminal(viewport_height: u16) -> io::Result<Terminal<CrosstermBackend<
         },
     ) {
         Ok(terminal) => Ok(terminal),
-        Err(_) => Terminal::new(CrosstermBackend::new(io::stdout())),
+        Err(_) => Terminal::new(CrosstermBackend::new(output.writer())),
     }
 }
 
-fn inline_viewport_height(max_height: u16) -> io::Result<u16> {
-    let _ = terminal::size()?;
-    Ok(compact_viewport_height(max_height))
+fn inline_viewport_height(max_height: u16) -> u16 {
+    compact_viewport_height(max_height)
 }
 
 pub(crate) fn compact_viewport_height(max_height: u16) -> u16 {
@@ -205,26 +205,74 @@ fn reload_after_edit<P: SuggestionProvider>(
     }
 }
 
+#[derive(Clone, Copy)]
+enum TuiOutputKind {
+    Stdout,
+    Stderr,
+}
+
+impl TuiOutputKind {
+    fn detect() -> Self {
+        if io::stdout().is_terminal() {
+            Self::Stdout
+        } else {
+            Self::Stderr
+        }
+    }
+
+    fn writer(self) -> TuiOutput {
+        match self {
+            Self::Stdout => TuiOutput::Stdout(io::stdout()),
+            Self::Stderr => TuiOutput::Stderr(io::stderr()),
+        }
+    }
+}
+
+enum TuiOutput {
+    Stdout(io::Stdout),
+    Stderr(io::Stderr),
+}
+
+impl Write for TuiOutput {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Stdout(stdout) => stdout.write(buf),
+            Self::Stderr(stderr) => stderr.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Stdout(stdout) => stdout.flush(),
+            Self::Stderr(stderr) => stderr.flush(),
+        }
+    }
+}
+
 /// RAII guard that enables terminal raw mode on construction and disables it
 /// on drop, even if the TUI exits via `?`.
 struct RawModeGuard {
     active: bool,
+    output: TuiOutputKind,
 }
 
 impl RawModeGuard {
-    fn enter() -> io::Result<Self> {
+    fn enter(output: TuiOutputKind) -> io::Result<Self> {
         enable_raw_mode()?;
         // Bracketed paste lets the terminal deliver pasted text as a single
         // Event::Paste(String) — preserving newlines — instead of a stream of
         // KeyCode::Char events that strip them. Best-effort: terminals that
         // don't support it silently ignore the escape.
-        let _ = execute!(io::stdout(), EnableBracketedPaste);
-        Ok(Self { active: true })
+        let _ = execute!(output.writer(), EnableBracketedPaste);
+        Ok(Self {
+            active: true,
+            output,
+        })
     }
 
     fn suspend(&mut self) -> io::Result<()> {
         if self.active {
-            let _ = execute!(io::stdout(), DisableBracketedPaste);
+            let _ = execute!(self.output.writer(), DisableBracketedPaste);
             disable_raw_mode()?;
             self.active = false;
         }
@@ -234,7 +282,7 @@ impl RawModeGuard {
     fn resume(&mut self) -> io::Result<()> {
         if !self.active {
             enable_raw_mode()?;
-            let _ = execute!(io::stdout(), EnableBracketedPaste);
+            let _ = execute!(self.output.writer(), EnableBracketedPaste);
             self.active = true;
         }
         Ok(())
@@ -244,97 +292,25 @@ impl RawModeGuard {
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
         if self.active {
-            let _ = execute!(io::stdout(), DisableBracketedPaste);
+            let _ = execute!(self.output.writer(), DisableBracketedPaste);
             let _ = disable_raw_mode();
         }
     }
 }
 
-/// RAII guard that redirects stdout to the TTY when stdout is not a terminal.
-///
-/// When peanutbutter is invoked via the shell hotkey (`pb`), bash captures
-/// stdout to write the selected command into the readline buffer. That means
-/// fd 1 is a pipe, not a terminal — we can't draw the TUI there. This guard
-/// saves fd 1, points it at stderr (if that's a terminal) or `/dev/tty`, and
-/// restores the original fd on drop so the caller can still print the command.
-struct StdoutTtyGuard {
-    saved_stdout: Option<OwnedFd>,
-}
-
-impl StdoutTtyGuard {
-    fn enter() -> io::Result<Self> {
-        if io::stdout().is_terminal() {
-            return Ok(Self { saved_stdout: None });
-        }
-
-        io::stdout().flush()?;
-        let saved = unsafe { libc::dup(libc::STDOUT_FILENO) };
-        if saved < 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        if io::stderr().is_terminal() {
-            if unsafe { libc::dup2(libc::STDERR_FILENO, libc::STDOUT_FILENO) } < 0 {
-                let _ = unsafe { libc::close(saved) };
-                return Err(io::Error::last_os_error());
-            }
-            return Ok(Self {
-                saved_stdout: Some(unsafe { OwnedFd::from_raw_fd(saved) }),
-            });
-        }
-
-        let tty = match fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open("/dev/tty")
-        {
-            Ok(tty) => tty,
-            Err(err) => {
-                let _ = unsafe { libc::close(saved) };
-                return Err(err);
-            }
-        };
-        if unsafe { libc::dup2(std::os::fd::AsRawFd::as_raw_fd(&tty), libc::STDOUT_FILENO) } < 0 {
-            let _ = unsafe { libc::close(saved) };
-            return Err(io::Error::last_os_error());
-        }
-        drop(tty);
-
-        Ok(Self {
-            saved_stdout: Some(unsafe { OwnedFd::from_raw_fd(saved) }),
-        })
-    }
-}
-
-impl Drop for StdoutTtyGuard {
-    fn drop(&mut self) {
-        let Some(saved_stdout) = &self.saved_stdout else {
-            return;
-        };
-        let _ = io::stdout().flush();
-        let _ = unsafe {
-            libc::dup2(
-                std::os::fd::AsRawFd::as_raw_fd(saved_stdout),
-                libc::STDOUT_FILENO,
-            )
-        };
-        let _ = io::stdout().flush();
-    }
-}
-
-fn cleanup_terminal(viewport_top: Option<u16>) -> io::Result<()> {
-    let mut stdout = io::stdout();
+fn cleanup_terminal(viewport_top: Option<u16>, output: TuiOutputKind) -> io::Result<()> {
+    let mut writer = output.writer();
     if let Some(y) = viewport_top {
         crossterm::execute!(
-            stdout,
+            writer,
             cursor::MoveTo(0, y),
             terminal::Clear(ClearType::FromCursorDown),
             cursor::Show
         )?;
     } else {
-        crossterm::execute!(stdout, cursor::Show)?;
+        crossterm::execute!(writer, cursor::Show)?;
     }
-    stdout.flush()?;
+    writer.flush()?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,15 @@ fn main() {
                 Err(err) => Err(err),
             }
         }
+        cli::Command::Powershell { binding } => {
+            match completions::powershell_integration_for_current_exe(&binding) {
+                Ok(script) => {
+                    print!("{script}");
+                    Ok(())
+                }
+                Err(err) => Err(err),
+            }
+        }
         cli::Command::Edit { path } => cli::run_edit_command(&paths, path.as_deref()).map(|_| ()),
         cli::Command::New { name, command } => match cli::run_new_command(
             &paths,


### PR DESCRIPTION
## Summary

- Add `peanutbutter powershell [C+b]` integration using PSReadLine `Insert(...)`, PowerShell `pb`/`peanutbutter` functions, history capture for `pb new`, and completions.
- Draw the execute TUI to stderr when stdout is captured, keeping shell-buffer command output clean across Unix shells and PowerShell.
- Add Windows MSVC release artifacts to unstable and tagged release workflows, with Windows target tests before packaging.

## Acceptance criteria

- [x] `peanutbutter powershell` emits PSReadLine glue equivalent to bash/zsh/fish integrations.
- [x] TUI output is routed away from captured stdout; Windows compile is verified with `x86_64-pc-windows-msvc`.
- [x] CI builds and tests a Windows release binary on push to main.
- [x] Windows release artifact is uploaded to GitHub Releases.

## Verification

```bash
cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo check --target x86_64-pc-windows-msvc
```
