### PR TITLE
feat(lsp): language server for snippet authoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,12 +87,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -154,6 +176,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -443,6 +471,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +528,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -581,6 +633,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +751,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -654,6 +797,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +895,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -810,6 +1062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +1095,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -1039,8 +1310,16 @@ dependencies = [
  "serde_json",
  "shell-words",
  "termimad",
+ "tokio",
  "toml",
+ "tower-lsp",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1138,10 +1417,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1430,6 +1744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,10 +1824,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1563,6 +1900,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1706,6 +2054,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +2137,97 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"
@@ -1798,6 +2281,25 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2212,6 +2714,89 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ termimad = "0.34"
 toml = "0.8"
 owo-colors = "4"
 shell-words = "1.1.1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std"] }
+tower-lsp = "0.20"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/docs/LSP.md
+++ b/docs/LSP.md
@@ -1,0 +1,106 @@
+# peanutbutter LSP
+
+`peanutbutter lsp` starts a Language Server Protocol server over stdio that
+gives editors a rich authoring experience for `.md` snippet files.
+
+## Features
+
+| Feature | Trigger |
+|---|---|
+| Diagnostics | Inline squiggles on open/save — lint findings from `pb lint` |
+| Completions | Frontmatter keys (`name`, `description`, `tags`, `variables`); variable spec sub-keys (`default`, `suggestions`, `command`); `<@variable>` placeholders in code blocks |
+| Hover | `<@name>` shows the resolved variable spec; frontmatter keys show brief docs |
+| Go-to-definition | `<@name>` in a code block → `variables.name:` in frontmatter |
+| Find references | Frontmatter variable declaration → every `<@name>` in the file |
+
+## Activation scope
+
+The server only activates for `.md` files that live under a directory tree
+containing a **marker file**. Any of the following names is accepted:
+
+| Filename | Style |
+|---|---|
+| `.peanutbutter.toml` | Hidden, tool-specific |
+| `peanutbutter.toml` | Visible config |
+| `_peanutbutter.toml` | Visible, underscore-prefixed |
+
+Create an empty marker file in the root of your snippet directory:
+
+```sh
+touch .peanutbutter.toml        # or peanutbutter.toml / _peanutbutter.toml
+```
+
+The server walks up from the open file's directory until it finds a marker.
+The directory containing the marker becomes the snippet root used for linting.
+Files outside any marked tree receive no diagnostics and no completions.
+
+When multiple nested markers exist the nearest ancestor wins, so monorepos
+with independent snippet roots work correctly.
+
+## Neovim setup
+
+### Option A — built-in `vim.lsp` (no plugins required)
+
+Add this to your Neovim config (`init.lua` or a plugin file):
+
+```lua
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "markdown",
+  callback = function()
+    vim.lsp.start({
+      name = "peanutbutter",
+      cmd = { "peanutbutter", "lsp" },
+      -- root_dir tells Neovim which directory to treat as the project root.
+      -- Here we walk up looking for a marker file, mirroring the server's own logic.
+      root_dir = (function()
+        local markers = { ".peanutbutter.toml", "peanutbutter.toml", "_peanutbutter.toml" }
+        return vim.fs.dirname(vim.fs.find(markers, { upward = true })[1])
+      end)(),
+    })
+  end,
+})
+```
+
+`vim.lsp.start` is idempotent: if an instance with the same `name` and
+`root_dir` is already running, Neovim reuses it rather than spawning a second
+process.
+
+### Option B — nvim-lspconfig
+
+If you use [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) you can
+register peanutbutter as a custom server:
+
+```lua
+local lspconfig = require("lspconfig")
+local lspconfig_configs = require("lspconfig.configs")
+
+if not lspconfig_configs.peanutbutter then
+  lspconfig_configs.peanutbutter = {
+    default_config = {
+      cmd = { "peanutbutter", "lsp" },
+      filetypes = { "markdown" },
+      root_dir = require("lspconfig.util").root_pattern(
+        ".peanutbutter.toml",
+        "peanutbutter.toml",
+        "_peanutbutter.toml"
+      ),
+      single_file_support = false,
+    },
+  }
+end
+
+lspconfig.peanutbutter.setup({})
+```
+
+### Completions
+
+Neovim's built-in `omnifunc` (`<C-x><C-o>`) works out of the box.  If you use
+a completion plugin, no extra configuration is needed — the server advertises
+`completionProvider` during the handshake and any LSP-aware plugin will pick it up.
+
+### Verifying the setup
+
+1. Open a `.md` file under a directory that contains a marker file.
+2. Run `:LspInfo` (nvim-lspconfig) or `:lua vim.print(vim.lsp.get_clients())` to confirm the `peanutbutter` client is attached.
+3. Introduce a lint error (e.g. add an unused `variables:` entry) and save — a warning squiggle should appear.
+4. Type `<@` inside a fenced code block and trigger completions — declared variable names should appear.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,6 +104,8 @@ pub enum Command {
     /// Internal shell completion helper for `--theme`.
     #[command(hide = true)]
     CompleteTheme { current: Option<String> },
+    /// Start a Language Server Protocol server over stdio for snippet authoring.
+    Lsp,
 }
 
 /// Result returned by [`run_execute_command`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! | [`config`] | TOML config loading and theme |
 //! | [`cli`] | Argument parsing and command dispatch |
 //! | [`execute`] | Interactive TUI (ratatui, crossterm) |
+//! | [`lsp`] | Language Server Protocol server (diagnostics, completions, hover, go-to-def) |
 
 pub mod browse;
 pub mod capture;
@@ -39,6 +40,7 @@ pub mod fuzzy;
 pub mod gc;
 pub mod index;
 pub mod lint;
+pub mod lsp;
 pub mod parser;
 pub mod search;
 pub(crate) mod shell;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -179,6 +179,38 @@ pub fn run<W: Write>(
     Ok(result)
 }
 
+/// Run single-file lint checks on in-memory content and return the findings.
+///
+/// This is intended for use by the LSP server, which re-parses documents on
+/// each change without reading from disk. Cross-file checks (unused config
+/// variables, duplicate slugs across files, GC) are not included.
+pub fn lint_file(path: &Path, root: &Path, content: &str, config: &AppConfig) -> Vec<LintFinding> {
+    let parsed = parser::parse_file(path, root, content);
+    let ctx = FileContext {
+        root: root.to_path_buf(),
+        path: path.to_path_buf(),
+        content: content.to_string(),
+        parsed,
+    };
+    let mut findings = Vec::new();
+    findings.extend(lint_frontmatter_source(path, content));
+    findings.extend(lint_duplicate_slugs(path, content));
+    findings.extend(lint_unused_file_variables(&ctx));
+    findings.extend(lint_suggestion_commands(
+        &ctx,
+        &config.variables,
+        &config.suggestion_commands,
+    ));
+    findings.extend(lint_static_inline_commands(&ctx));
+    findings.extend(lint_markdown_structure(path, content));
+    findings.extend(lint_missing_code_languages(&ctx));
+    findings.extend(lint_frontmatter_overrides(&ctx, &config.variables));
+    attach_suppress_paths(&mut findings, &[ctx]);
+    findings.retain(|f| !is_suppressed(f, &config.lint));
+    sort_findings(&mut findings);
+    findings
+}
+
 fn validate_roots(roots: &[PathBuf]) -> io::Result<()> {
     for root in roots {
         match fs::metadata(root) {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,0 +1,717 @@
+//! Language Server Protocol server for peanutbutter snippet files.
+//!
+//! Starts an LSP server over stdio (`peanutbutter lsp`) that provides:
+//! - **Diagnostics** — lint findings published on open/change
+//! - **Completions** — frontmatter keys and `<@variable>` placeholders
+//! - **Hover** — variable spec on `<@name>` and docs on frontmatter keys
+//! - **Go-to-definition** — `<@name>` in a code block → `variables.name:` in frontmatter
+//!
+//! # Activation scope
+//!
+//! The server only activates for `.md` files that sit under a directory tree
+//! containing one of the marker files listed in [`MARKER_FILENAMES`]. The
+//! marker directory becomes the snippet root used for linting. Files outside
+//! any marked tree receive empty diagnostics and no completions/hover/definitions.
+
+use crate::config::{self, AppConfig};
+use crate::lint;
+use crate::parser;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+/// Run the LSP server over stdio until the client disconnects.
+pub fn run_lsp_server() {
+    let config = match config::load() {
+        Ok(c) => c,
+        Err(err) => {
+            eprintln!("peanutbutter-lsp: failed to load config: {err}");
+            return;
+        }
+    };
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        let stdin = tokio::io::stdin();
+        let stdout = tokio::io::stdout();
+        let (service, socket) = LspService::new(|client| Backend {
+            client,
+            documents: RwLock::new(HashMap::new()),
+            config: Arc::new(config),
+        });
+        Server::new(stdin, stdout, socket).serve(service).await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+struct Backend {
+    client: Client,
+    /// In-memory document store: URI → current text content.
+    documents: RwLock<HashMap<Url, String>>,
+    config: Arc<AppConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// LSP implementation
+// ---------------------------------------------------------------------------
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, _params: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![
+                        "<".to_string(),
+                        "@".to_string(),
+                        " ".to_string(),
+                        ":".to_string(),
+                    ]),
+                    ..Default::default()
+                }),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                definition_provider: Some(OneOf::Left(true)),
+                references_provider: Some(OneOf::Left(true)),
+                ..Default::default()
+            },
+            server_info: Some(ServerInfo {
+                name: "peanutbutter-lsp".to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "peanutbutter LSP ready")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let text = params.text_document.text;
+        self.documents
+            .write()
+            .await
+            .insert(uri.clone(), text.clone());
+        self.publish_diagnostics(&uri, &text).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        // Full sync: last content_change is the full document.
+        if let Some(change) = params.content_changes.into_iter().last() {
+            self.documents
+                .write()
+                .await
+                .insert(uri.clone(), change.text.clone());
+            self.publish_diagnostics(&uri, &change.text).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = params.text_document.uri;
+        self.documents.write().await.remove(&uri);
+        // Clear diagnostics when the file is closed.
+        self.client.publish_diagnostics(uri, vec![], None).await;
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let uri = &params.text_document_position.text_document.uri;
+        let pos = params.text_document_position.position;
+        if find_marker_root(&uri_to_path(uri)).is_none() {
+            return Ok(None);
+        }
+        let docs = self.documents.read().await;
+        let Some(content) = docs.get(uri) else {
+            return Ok(None);
+        };
+        Ok(compute_completions(content, pos))
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+        if find_marker_root(&uri_to_path(uri)).is_none() {
+            return Ok(None);
+        }
+        let docs = self.documents.read().await;
+        let Some(content) = docs.get(uri) else {
+            return Ok(None);
+        };
+        Ok(compute_hover(content, pos))
+    }
+
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+        if find_marker_root(&uri_to_path(uri)).is_none() {
+            return Ok(None);
+        }
+        let docs = self.documents.read().await;
+        let Some(content) = docs.get(uri) else {
+            return Ok(None);
+        };
+        Ok(compute_definition(uri, content, pos))
+    }
+
+    async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
+        let uri = &params.text_document_position.text_document.uri;
+        let pos = params.text_document_position.position;
+        if find_marker_root(&uri_to_path(uri)).is_none() {
+            return Ok(None);
+        }
+        let docs = self.documents.read().await;
+        let Some(content) = docs.get(uri) else {
+            return Ok(None);
+        };
+        Ok(compute_references(uri, content, pos))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+impl Backend {
+    async fn publish_diagnostics(&self, uri: &Url, content: &str) {
+        let path = uri_to_path(uri);
+        let Some(root) = find_marker_root(&path) else {
+            // Outside a peanutbutter snippet tree; clear any stale diagnostics.
+            self.client
+                .publish_diagnostics(uri.clone(), vec![], None)
+                .await;
+            return;
+        };
+        let findings = lint::lint_file(&path, &root, content, &self.config);
+        let diagnostics = findings
+            .iter()
+            .map(|f| lint_finding_to_diagnostic(f, content))
+            .collect();
+        self.client
+            .publish_diagnostics(uri.clone(), diagnostics, None)
+            .await;
+    }
+}
+
+/// Convert a document URI to an absolute filesystem path.
+fn uri_to_path(uri: &Url) -> PathBuf {
+    uri.to_file_path()
+        .unwrap_or_else(|_| PathBuf::from(uri.path()))
+}
+
+/// Convert a [`LintFinding`] to an LSP [`Diagnostic`].
+///
+/// Line numbers in findings are 1-based; LSP positions are 0-based.
+fn lint_finding_to_diagnostic(finding: &lint::LintFinding, content: &str) -> Diagnostic {
+    let line = finding.line.unwrap_or(1).saturating_sub(1) as u32;
+    let line_len = content
+        .lines()
+        .nth(line as usize)
+        .map(|l| l.len() as u32)
+        .unwrap_or(0);
+    let range = Range {
+        start: Position { line, character: 0 },
+        end: Position {
+            line,
+            character: line_len,
+        },
+    };
+    let severity = match finding.severity {
+        lint::LintSeverity::Error => DiagnosticSeverity::ERROR,
+        lint::LintSeverity::Warning => DiagnosticSeverity::WARNING,
+    };
+    let message = match &finding.detail {
+        Some(detail) => format!("{}\n{detail}", finding.message),
+        None => finding.message.clone(),
+    };
+    Diagnostic {
+        range,
+        severity: Some(severity),
+        code: Some(NumberOrString::String(finding.code.to_string())),
+        source: Some("peanutbutter".to_string()),
+        message,
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Completions
+// ---------------------------------------------------------------------------
+
+/// Known top-level frontmatter keys with documentation.
+const FRONTMATTER_KEYS: &[(&str, &str)] = &[
+    ("name", "Human-readable title for this snippet file"),
+    (
+        "description",
+        "Short prose description of the file contents",
+    ),
+    ("tags", "Searchable tags (e.g. `[git, shell]`)"),
+    ("variables", "File-local variable input specifications"),
+];
+
+/// Known sub-keys under `variables.<name>:` with documentation.
+const VARIABLE_SPEC_KEYS: &[(&str, &str)] = &[
+    (
+        "default",
+        "Pre-populated value shown in the prompt input box",
+    ),
+    (
+        "suggestions",
+        "Fixed suggestion values shown in the suggestion list",
+    ),
+    (
+        "command",
+        "Shell command whose stdout lines are used as suggestions",
+    ),
+];
+
+fn compute_completions(content: &str, pos: Position) -> Option<CompletionResponse> {
+    let lines: Vec<&str> = content.lines().collect();
+    let line_idx = pos.line as usize;
+    let char_idx = pos.character as usize;
+    let current_line = lines.get(line_idx).copied().unwrap_or("");
+
+    // Detect context
+    let fm_end = frontmatter_end_line(&lines);
+    let in_frontmatter = fm_end
+        .map(|end| line_idx > 0 && line_idx < end)
+        .unwrap_or(false);
+
+    if in_frontmatter {
+        // Are we inside a `variables:` block (indented)?
+        let indent = current_line.len() - current_line.trim_start().len();
+        if indent >= 2 {
+            // Could be inside a variable spec; check if parent block is `variables:`.
+            let in_var_block = lines[..line_idx]
+                .iter()
+                .rev()
+                .any(|l| l.trim() == "variables:");
+            if in_var_block {
+                // Completing variable spec sub-keys or an inner list item
+                let trimmed = current_line.trim_start();
+                let prefix = trimmed.split(':').next().unwrap_or("").trim();
+                let items = VARIABLE_SPEC_KEYS
+                    .iter()
+                    .filter(|(k, _)| k.starts_with(prefix))
+                    .map(|(k, doc)| completion_item(k, doc, CompletionItemKind::FIELD))
+                    .collect();
+                return Some(CompletionResponse::Array(items));
+            }
+        }
+        // Top-level frontmatter key completion
+        let prefix = current_line
+            .trim_start()
+            .split(':')
+            .next()
+            .unwrap_or("")
+            .trim();
+        let items = FRONTMATTER_KEYS
+            .iter()
+            .filter(|(k, _)| k.starts_with(prefix))
+            .map(|(k, doc)| completion_item(k, doc, CompletionItemKind::FIELD))
+            .collect();
+        return Some(CompletionResponse::Array(items));
+    }
+
+    // Inside a code block — offer `<@variable>` completions when user typed `<@`
+    let before_cursor = &current_line[..char_idx.min(current_line.len())];
+    if before_cursor.ends_with("<@") || before_cursor.contains("<@") {
+        // Extract the prefix after `<@`
+        let at_pos = before_cursor.rfind("<@").map(|i| i + 2).unwrap_or(0);
+        let var_prefix = &before_cursor[at_pos..];
+        // Collect declared frontmatter variables
+        let parsed =
+            parser::parse_file(std::path::Path::new(""), std::path::Path::new(""), content);
+        let items: Vec<CompletionItem> = parsed
+            .frontmatter
+            .variables
+            .keys()
+            .filter(|name| name.starts_with(var_prefix))
+            .map(|name| {
+                let spec = &parsed.frontmatter.variables[name];
+                let detail = variable_spec_summary(spec);
+                let mut item = completion_item(name, &detail, CompletionItemKind::VARIABLE);
+                // Insert the full placeholder including closing `>`
+                item.insert_text = Some(format!("{name}>"));
+                item.insert_text_format = Some(InsertTextFormat::PLAIN_TEXT);
+                item
+            })
+            .collect();
+        return Some(CompletionResponse::Array(items));
+    }
+
+    None
+}
+
+fn completion_item(label: &str, documentation: &str, kind: CompletionItemKind) -> CompletionItem {
+    CompletionItem {
+        label: label.to_string(),
+        kind: Some(kind),
+        documentation: Some(Documentation::String(documentation.to_string())),
+        ..Default::default()
+    }
+}
+
+fn variable_spec_summary(spec: &crate::domain::VariableSpec) -> String {
+    let mut parts = Vec::new();
+    if let Some(d) = &spec.default {
+        parts.push(format!("default: `{d}`"));
+    }
+    if !spec.suggestions.is_empty() {
+        parts.push(format!("suggestions: {}", spec.suggestions.join(", ")));
+    }
+    if let Some(cmd) = &spec.command {
+        parts.push(format!("command: `{cmd}`"));
+    }
+    if parts.is_empty() {
+        "free-form input".to_string()
+    } else {
+        parts.join("\n")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hover
+// ---------------------------------------------------------------------------
+
+fn compute_hover(content: &str, pos: Position) -> Option<Hover> {
+    let lines: Vec<&str> = content.lines().collect();
+    let line_idx = pos.line as usize;
+    let char_idx = pos.character as usize;
+    let current_line = lines.get(line_idx).copied()?;
+
+    let fm_end = frontmatter_end_line(&lines);
+    let in_frontmatter = fm_end
+        .map(|end| line_idx > 0 && line_idx < end)
+        .unwrap_or(false);
+
+    if in_frontmatter {
+        return hover_frontmatter_key(current_line, pos);
+    }
+
+    // Check if cursor is on a `<@name>` or `<@name:source>` placeholder
+    hover_variable_placeholder(content, current_line, char_idx, pos)
+}
+
+fn hover_frontmatter_key(line: &str, pos: Position) -> Option<Hover> {
+    let key = line.trim_start().split(':').next()?.trim();
+    let doc = FRONTMATTER_KEYS
+        .iter()
+        .find(|(k, _)| *k == key)
+        .map(|(_, doc)| *doc)?;
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!("**`{key}`** — {doc}"),
+        }),
+        range: Some(line_range(pos.line, 0, key.len() as u32)),
+    })
+}
+
+fn hover_variable_placeholder(
+    content: &str,
+    line: &str,
+    char_idx: usize,
+    pos: Position,
+) -> Option<Hover> {
+    let (name, start, end) = placeholder_at(line, char_idx)?;
+    let parsed = parser::parse_file(std::path::Path::new(""), std::path::Path::new(""), content);
+    let spec = parsed.frontmatter.variables.get(&name)?;
+    let mut md = format!("**`<@{name}>`**\n\n");
+    if let Some(d) = &spec.default {
+        md.push_str(&format!("- **default**: `{d}`\n"));
+    }
+    if !spec.suggestions.is_empty() {
+        md.push_str(&format!(
+            "- **suggestions**: {}\n",
+            spec.suggestions.join(", ")
+        ));
+    }
+    if let Some(cmd) = &spec.command {
+        md.push_str(&format!("- **command**: `{cmd}`\n"));
+    }
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: md,
+        }),
+        range: Some(line_range(pos.line, start as u32, end as u32)),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Go-to-definition
+// ---------------------------------------------------------------------------
+
+fn compute_definition(uri: &Url, content: &str, pos: Position) -> Option<GotoDefinitionResponse> {
+    let lines: Vec<&str> = content.lines().collect();
+    let line_idx = pos.line as usize;
+    let char_idx = pos.character as usize;
+    let current_line = lines.get(line_idx).copied()?;
+
+    let (name, _, _) = placeholder_at(current_line, char_idx)?;
+
+    // Find the declaration line inside `variables:` frontmatter block.
+    let def_line = find_variable_declaration_line(&lines, &name)?;
+    let target_range = line_range(def_line as u32, 0, lines[def_line].len() as u32);
+    Some(GotoDefinitionResponse::Scalar(Location {
+        uri: uri.clone(),
+        range: target_range,
+    }))
+}
+
+/// Find the 0-based line index of `  <name>:` inside the `variables:` frontmatter block.
+fn find_variable_declaration_line(lines: &[&str], name: &str) -> Option<usize> {
+    let fm_end = frontmatter_end_line(lines)?;
+    let mut in_variables = false;
+    for (i, line) in lines[1..fm_end].iter().enumerate() {
+        let actual_line = i + 1;
+        let trimmed = line.trim_start();
+        if trimmed == "variables:" {
+            in_variables = true;
+            continue;
+        }
+        if in_variables {
+            let indent = line.len() - trimmed.len();
+            if indent == 0 {
+                // Back to top-level key, variables block ended.
+                break;
+            }
+            if indent >= 2 {
+                // Could be `  name:` — check for variable name at exactly 2-space indent.
+                let key = trimmed.split(':').next().unwrap_or("").trim();
+                if key == name {
+                    return Some(actual_line);
+                }
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Find references
+// ---------------------------------------------------------------------------
+
+fn compute_references(uri: &Url, content: &str, pos: Position) -> Option<Vec<Location>> {
+    let lines: Vec<&str> = content.lines().collect();
+    let line_idx = pos.line as usize;
+    let current_line = lines.get(line_idx).copied()?;
+
+    // If cursor is on the variable declaration in frontmatter, find all `<@name>` usages.
+    let fm_end = frontmatter_end_line(&lines)?;
+    let in_frontmatter = line_idx > 0 && line_idx < fm_end;
+
+    let var_name: String;
+    if in_frontmatter {
+        // Check if this line is a variable declaration line (inside `variables:` block).
+        let trimmed = current_line.trim_start();
+        var_name = trimmed.split(':').next()?.trim().to_string();
+        // Verify it is actually declared in frontmatter variables.
+        let parsed =
+            parser::parse_file(std::path::Path::new(""), std::path::Path::new(""), content);
+        if !parsed.frontmatter.variables.contains_key(&var_name) {
+            return None;
+        }
+    } else {
+        // Cursor might be on a placeholder.
+        let char_idx = pos.character as usize;
+        let (name, _, _) = placeholder_at(current_line, char_idx)?;
+        var_name = name;
+    }
+
+    // Find all `<@var_name` occurrences in the document.
+    let pattern = format!("<@{var_name}");
+    let mut locations = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        let mut search_from = 0;
+        while let Some(col) = line[search_from..].find(&pattern) {
+            let abs_col = search_from + col;
+            let end_col = abs_col + pattern.len();
+            locations.push(Location {
+                uri: uri.clone(),
+                range: line_range(i as u32, abs_col as u32, end_col as u32),
+            });
+            search_from = abs_col + 1;
+        }
+    }
+    Some(locations)
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Marker file names that identify a directory tree as a peanutbutter snippet root.
+///
+/// The server only activates for `.md` files that have one of these files in
+/// an ancestor directory. Any of the three names is accepted so teams can pick
+/// a convention that fits their project layout.
+pub const MARKER_FILENAMES: &[&str] = &[
+    ".peanutbutter.toml",
+    "peanutbutter.toml",
+    "_peanutbutter.toml",
+];
+
+/// Walk up from `path`'s parent directory looking for any [`MARKER_FILENAMES`].
+///
+/// Returns the directory that contains the marker file, which becomes the
+/// snippet root used for linting and snippet ID construction. Returns `None`
+/// when no marker is found before reaching the filesystem root.
+fn find_marker_root(path: &Path) -> Option<PathBuf> {
+    let mut dir = path.parent()?;
+    loop {
+        for name in MARKER_FILENAMES {
+            if dir.join(name).exists() {
+                return Some(dir.to_path_buf());
+            }
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return None,
+        }
+    }
+}
+
+/// Return the 0-based line index of the closing `---` of the frontmatter block,
+/// or `None` if there is no valid frontmatter.
+fn frontmatter_end_line(lines: &[&str]) -> Option<usize> {
+    if lines.first().map(|l| l.trim()) != Some("---") {
+        return None;
+    }
+    lines[1..]
+        .iter()
+        .position(|l| l.trim() == "---")
+        .map(|i| i + 1)
+}
+
+/// Extract the variable name and byte span `[start, end)` of a `<@name…>` or
+/// `<@name:…>` placeholder that the cursor (at `char_idx`) sits within.
+fn placeholder_at(line: &str, char_idx: usize) -> Option<(String, usize, usize)> {
+    // Scan for `<@…>` spans overlapping the cursor position.
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len().saturating_sub(1) {
+        if bytes[i] == b'<' && bytes[i + 1] == b'@' {
+            let start = i;
+            // Find closing `>`
+            let end = match bytes[start..].iter().position(|&b| b == b'>') {
+                Some(rel) => start + rel + 1,
+                None => bytes.len(),
+            };
+            if char_idx >= start && char_idx <= end {
+                // Extract name: everything between `<@` and the first `:` or `>`
+                let inner = &line[start + 2..end.min(bytes.len()) - 1];
+                let name = inner.split(':').next().unwrap_or(inner).to_string();
+                return Some((name, start, end));
+            }
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// Build a single-line [`Range`] from 0-based line + character column bounds.
+fn line_range(line: u32, start_char: u32, end_char: u32) -> Range {
+    Range {
+        start: Position {
+            line,
+            character: start_char,
+        },
+        end: Position {
+            line,
+            character: end_char,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmp_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "pb-lsp-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn find_marker_root_dot_peanutbutter_toml() {
+        let root = tmp_dir();
+        fs::write(root.join(".peanutbutter.toml"), "").unwrap();
+        let file = root.join("sub").join("snippets.md");
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        fs::write(&file, "").unwrap();
+        assert_eq!(find_marker_root(&file), Some(root.clone()));
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn find_marker_root_peanutbutter_toml() {
+        let root = tmp_dir();
+        fs::write(root.join("peanutbutter.toml"), "").unwrap();
+        let file = root.join("snippets.md");
+        fs::write(&file, "").unwrap();
+        assert_eq!(find_marker_root(&file), Some(root.clone()));
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn find_marker_root_underscore_peanutbutter_toml() {
+        let root = tmp_dir();
+        fs::write(root.join("_peanutbutter.toml"), "").unwrap();
+        let file = root.join("snippets.md");
+        fs::write(&file, "").unwrap();
+        assert_eq!(find_marker_root(&file), Some(root.clone()));
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn find_marker_root_returns_none_when_no_marker() {
+        let root = tmp_dir();
+        let file = root.join("snippets.md");
+        fs::write(&file, "").unwrap();
+        assert_eq!(find_marker_root(&file), None);
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn find_marker_root_nearest_ancestor_wins() {
+        // Inner marker should win over outer one.
+        let outer = tmp_dir();
+        let inner = outer.join("sub");
+        fs::create_dir_all(&inner).unwrap();
+        fs::write(outer.join(".peanutbutter.toml"), "").unwrap();
+        fs::write(inner.join("peanutbutter.toml"), "").unwrap();
+        let file = inner.join("snippets.md");
+        fs::write(&file, "").unwrap();
+        assert_eq!(find_marker_root(&file), Some(inner.clone()));
+        fs::remove_dir_all(&outer).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,10 @@ fn main() {
             }
             Err(err) => Err(err),
         },
+        cli::Command::Lsp => {
+            peanutbutter::lsp::run_lsp_server();
+            Ok(())
+        }
     };
 
     if let Err(err) = result {


### PR DESCRIPTION
## Why

Generic markdown language servers know nothing about peanutbutter's snippet format — frontmatter variables, `<@placeholder>` syntax, or the lint rules. This adds `peanutbutter lsp`, a stdio LSP server backed by the existing parser and lint engine, so editors get inline feedback and smart completions without any extra tooling.

Closes #31.

## What

- **`peanutbutter lsp` subcommand** — starts a `tower-lsp` server over stdio; editors attach via `cmd = ["peanutbutter", "lsp"]`
- **Diagnostics** — `lint::lint_file` (new public function) runs all per-file checks on in-memory content on every `didOpen`/`didChange`; findings appear as inline squiggles with severity and lint code
- **Completions** — frontmatter top-level keys (`name`, `description`, `tags`, `variables`) and variable spec sub-keys (`default`, `suggestions`, `command`); `<@var>` placeholder names from declared frontmatter variables inside code blocks
- **Hover** — `<@name>` shows the resolved variable spec (default, suggestions, command); frontmatter keys show brief inline docs
- **Go-to-definition** — `<@name>` in a code block jumps to `variables.name:` in frontmatter
- **Find references** — frontmatter variable declaration highlights every `<@name>` in the file (and vice versa)
- **Activation scope** — server only activates for `.md` files under a directory tree containing `.peanutbutter.toml`, `peanutbutter.toml`, or `_peanutbutter.toml`; files outside any marked tree receive empty responses
- **`docs/LSP.md`** — Neovim setup guide covering both built-in `vim.lsp` and `nvim-lspconfig`

## Verification

```bash
cargo fmt --check && cargo clippy -- -D warnings && cargo test
```

LSP handshake smoke test:
```bash
MSG='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}'; \
printf "Content-Length: ${#MSG}\r\n\r\n${MSG}" | peanutbutter lsp
# → InitializeResult with completionProvider, hoverProvider, definitionProvider, referencesProvider
```

Marker gating: 5 unit tests in `lsp::tests` cover all three marker filenames, the no-marker case, and nearest-ancestor precedence.

## Review focus

- `lint::lint_file` runs suggestion commands synchronously inside the LSP handler (same as `pb lint`). For files with slow `command:` variables this could block the async runtime briefly. Acceptable for now; can be moved to `spawn_blocking` if it becomes a problem.
- The marker walk hits the filesystem on every request (completion, hover, definition). It's a cheap `exists()` check up a short ancestor chain, but it could be cached per-document if latency becomes measurable.
- Cross-file lint checks (unused config variables, GC orphans, duplicate slugs across files) are intentionally excluded from `lint_file` — they require loading the full snippet tree and don't fit the per-document LSP model.