### PR TITLE
refactor: nest shell integration under completions subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ New here? Run `pb init` once to scaffold starter snippets at the default XDG loc
 **bash** — add to `~/.bashrc`:
 
 ```bash
-eval "$(peanutbutter bash)"
+eval "$(peanutbutter completions bash)"
 # then press Ctrl + b and have fun.
 # also installs `pb` as a bash alias for `peanutbutter`
 ```
@@ -52,19 +52,19 @@ eval "$(peanutbutter bash)"
 **zsh** — add to `~/.zshrc`:
 
 ```zsh
-eval "$(peanutbutter zsh)"
+eval "$(peanutbutter completions zsh)"
 ```
 
 **fish** — add to `~/.config/fish/config.fish`:
 
 ```fish
-peanutbutter fish | source
+peanutbutter completions fish | source
 ```
 
 **PowerShell** — add to `$PROFILE`:
 
 ```powershell
-peanutbutter powershell | Invoke-Expression
+peanutbutter completions powershell | Invoke-Expression
 ```
 
 ## Why

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::completions;
 use crate::config::Paths;
 use crate::execute::{self, ExecuteOptions, ExecutionOutcome};
 use crate::frecency::FrecencyStore;
@@ -54,23 +55,10 @@ pub enum Command {
         #[arg(last = true)]
         command: Vec<String>,
     },
-    /// Emit shell integration code for the given readline binding.
-    Bash {
-        #[arg(default_value = "C+b")]
-        binding: String,
-    },
-    /// Emit zsh integration code for the given ZLE binding.
-    Zsh {
-        #[arg(default_value = "C+b")]
-        binding: String,
-    },
-    /// Emit fish integration code for the given key binding.
-    Fish {
-        #[arg(default_value = "C+b")]
-        binding: String,
-    },
-    /// Emit PowerShell integration code for the given PSReadLine binding.
-    Powershell {
+    /// Emit shell integration code for the given shell and key binding.
+    Completions {
+        /// Which shell to emit integration code for.
+        shell: completions::Shell,
         #[arg(default_value = "C+b")]
         binding: String,
     },
@@ -393,26 +381,29 @@ mod tests {
             })
         );
         assert_eq!(
-            Cli::try_parse_from(["peanutbutter", "bash"])
+            Cli::try_parse_from(["peanutbutter", "completions", "bash"])
                 .unwrap()
                 .command,
-            Some(Command::Bash {
+            Some(Command::Completions {
+                shell: completions::Shell::Bash,
                 binding: "C+b".to_string()
             })
         );
         assert_eq!(
-            Cli::try_parse_from(["peanutbutter", "bash", "C+f"])
+            Cli::try_parse_from(["peanutbutter", "completions", "bash", "C+f"])
                 .unwrap()
                 .command,
-            Some(Command::Bash {
+            Some(Command::Completions {
+                shell: completions::Shell::Bash,
                 binding: "C+f".to_string()
             })
         );
         assert_eq!(
-            Cli::try_parse_from(["peanutbutter", "powershell"])
+            Cli::try_parse_from(["peanutbutter", "completions", "powershell"])
                 .unwrap()
                 .command,
-            Some(Command::Powershell {
+            Some(Command::Completions {
+                shell: completions::Shell::Powershell,
                 binding: "C+b".to_string()
             })
         );
@@ -500,12 +491,12 @@ mod tests {
     }
 
     #[test]
-    fn clap_help_mentions_bash_subcommand() {
+    fn clap_help_mentions_completions_subcommand() {
         let mut command = <Cli as clap::CommandFactory>::command();
         let mut help = Vec::new();
         command.write_long_help(&mut help).unwrap();
         let help = String::from_utf8(help).unwrap();
-        assert!(help.contains("bash"));
+        assert!(help.contains("completions"));
         assert!(!help.contains("--bash"));
     }
 

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -10,8 +10,21 @@ use std::env;
 use std::io;
 use std::path::Path;
 
+/// Shell targeted by `peanutbutter completions <shell>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Shell {
+    /// Emit bash integration code.
+    Bash,
+    /// Emit zsh integration code.
+    Zsh,
+    /// Emit fish integration code.
+    Fish,
+    /// Emit PowerShell integration code.
+    Powershell,
+}
+
 /// Emit the bash integration script using the path of the currently running
-/// executable. Intended for `peanutbutter bash`; the caller should `eval` the
+/// executable. Intended for `peanutbutter completions bash`; the caller should `eval` the
 /// output in their shell init file.
 pub fn bash_integration_for_current_exe(binding: &str) -> io::Result<String> {
     let exe = env::current_exe()?;
@@ -77,7 +90,11 @@ __pb_complete() {{
     done < <({executable} complete-edit "$cur")
     return 0
   fi
-  COMPREPLY=( $(compgen -W "--theme bash edit execute zsh fish powershell lint gc new stats" -- "$cur") )
+  if [[ "$subcommand" == "completions" ]]; then
+    COMPREPLY=( $(compgen -W "bash zsh fish powershell" -- "$cur") )
+    return 0
+  fi
+  COMPREPLY=( $(compgen -W "--theme completions edit execute lint gc new stats" -- "$cur") )
 }}
 complete -o nospace -F __pb_complete {BINARY_NAME} {BASH_ALIAS_NAME}
 "#
@@ -145,8 +162,10 @@ _pb_complete() {{
     local -a candidates
     candidates=( ${{(f)"$({executable} complete-edit "${{words[CURRENT]}}")"}} )
     compadd -S '' -- "${{candidates[@]}}"
+  elif [[ "${{words[2]}}" == "completions" ]]; then
+    compadd -- bash zsh fish powershell
   else
-    compadd -- --theme bash edit execute zsh fish powershell lint gc new stats
+    compadd -- --theme completions edit execute lint gc new stats
   fi
 }}
 compdef _pb_complete {BINARY_NAME} {BASH_ALIAS_NAME}
@@ -206,15 +225,16 @@ function {BINARY_NAME}
   __pb_dispatch $argv
 end
 complete -c {BINARY_NAME} -f -l theme -a '(__pb_complete_theme)'
-complete -c {BINARY_NAME} -f -n 'not __fish_seen_subcommand_from bash edit execute zsh fish powershell lint gc new stats' -a 'bash edit execute zsh fish powershell lint gc new stats'
+complete -c {BINARY_NAME} -f -n 'not __fish_seen_subcommand_from completions edit execute lint gc new stats' -a 'completions edit execute lint gc new stats'
 complete -c {BINARY_NAME} -f -n '__fish_seen_subcommand_from edit' -a '(__pb_complete_edit)'
+complete -c {BINARY_NAME} -f -n '__fish_seen_subcommand_from completions' -a 'bash zsh fish powershell'
 complete -c {BASH_ALIAS_NAME} -w {BINARY_NAME}
 "#
     ))
 }
 
 /// Emit the PowerShell integration script using the path of the currently running
-/// executable. Intended for `peanutbutter powershell`; the caller should add the
+/// executable. Intended for `peanutbutter completions powershell`; the caller should add the
 /// output to their PowerShell profile.
 pub fn powershell_integration_for_current_exe(binding: &str) -> io::Result<String> {
     let exe = env::current_exe()?;
@@ -255,8 +275,10 @@ Register-ArgumentCompleter -CommandName {BINARY_NAME},{BASH_ALIAS_NAME} -ScriptB
     & $script:__pb_exe complete-theme $wordToComplete | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
   }} elseif ($words.Count -ge 2 -and $words[1] -eq 'edit') {{
     & $script:__pb_exe complete-edit $wordToComplete | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
+  }} elseif ($words.Count -ge 2 -and $words[1] -eq 'completions') {{
+    'bash','zsh','fish','powershell' | Where-Object {{ $_ -like "$wordToComplete*" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
   }} else {{
-    'bash','edit','execute','zsh','fish','powershell','lint','gc','new','stats','--theme' | Where-Object {{ $_ -like "$wordToComplete*" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
+    'completions','edit','execute','lint','gc','new','stats','--theme' | Where-Object {{ $_ -like "$wordToComplete*" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
   }}
 }}
 "#
@@ -346,7 +368,8 @@ mod tests {
     #[test]
     fn bash_script_completion_word_list_includes_all_shells() {
         let script = bash_integration_script("C+b", Path::new("/tmp/peanutbutter")).unwrap();
-        assert!(script.contains("bash edit execute zsh fish powershell lint gc new stats"));
+        assert!(script.contains("--theme completions edit execute lint gc new stats"));
+        assert!(script.contains("compgen -W \"bash zsh fish powershell\""));
         assert!(script.contains("complete-theme \"$cur\""));
         assert!(script.contains("--theme"));
     }
@@ -493,7 +516,8 @@ mod tests {
         assert!(script.contains("Register-ArgumentCompleter -CommandName peanutbutter,pb"));
         assert!(script.contains("complete-edit $wordToComplete"));
         assert!(script.contains("complete-theme $wordToComplete"));
-        assert!(script.contains("'powershell'"));
+        assert!(script.contains("'completions'"));
+        assert!(script.contains("'bash','zsh','fish','powershell'"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub(crate) mod tui;
 
 /// The binary name used in help text and warning messages.
 pub const BINARY_NAME: &str = "peanutbutter";
-/// The shell alias installed by `peanutbutter bash`.
+/// The shell alias installed by `peanutbutter completions bash`.
 pub const BASH_ALIAS_NAME: &str = "pb";
 
 /// Exit status emitted by `execute` when the selected snippet consumed the

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,35 +101,16 @@ fn main() {
             let _ = stdout.flush();
             result
         }
-        cli::Command::Bash { binding } => {
-            match completions::bash_integration_for_current_exe(&binding) {
-                Ok(script) => {
-                    print!("{script}");
-                    Ok(())
+        cli::Command::Completions { shell, binding } => {
+            let script = match shell {
+                completions::Shell::Bash => completions::bash_integration_for_current_exe(&binding),
+                completions::Shell::Zsh => completions::zsh_integration_for_current_exe(&binding),
+                completions::Shell::Fish => completions::fish_integration_for_current_exe(&binding),
+                completions::Shell::Powershell => {
+                    completions::powershell_integration_for_current_exe(&binding)
                 }
-                Err(err) => Err(err),
-            }
-        }
-        cli::Command::Zsh { binding } => {
-            match completions::zsh_integration_for_current_exe(&binding) {
-                Ok(script) => {
-                    print!("{script}");
-                    Ok(())
-                }
-                Err(err) => Err(err),
-            }
-        }
-        cli::Command::Fish { binding } => {
-            match completions::fish_integration_for_current_exe(&binding) {
-                Ok(script) => {
-                    print!("{script}");
-                    Ok(())
-                }
-                Err(err) => Err(err),
-            }
-        }
-        cli::Command::Powershell { binding } => {
-            match completions::powershell_integration_for_current_exe(&binding) {
+            };
+            match script {
                 Ok(script) => {
                     print!("{script}");
                     Ok(())

--- a/src/new.rs
+++ b/src/new.rs
@@ -42,7 +42,7 @@ pub fn run_new_command(
         if entries.is_empty() {
             return Err(io::Error::other(
                 "pb new: no shell history available. Source the shell integration \
-                 (e.g. eval \"$(peanutbutter bash C+b)\") and re-run, or bypass with: \
+                 (e.g. eval \"$(peanutbutter completions bash C+b)\") and re-run, or bypass with: \
                  pb new <name> -- <command...>",
             ));
         }


### PR DESCRIPTION
## Summary
- Replace the four top-level `bash`/`zsh`/`fish`/`powershell` subcommands with a single nested `pb completions <shell>` subcommand (`shell` is a clap `ValueEnum`)
- Update `main.rs` dispatch to match on `completions::Shell`
- Update the generated bash/zsh/fish/PowerShell completion scripts so their candidate lists and nested-completion logic reflect `completions bash|zsh|fish|powershell` instead of top-level shell names
- Update README quick-start examples and doc comments to `peanutbutter completions bash` / `zsh` / `fish` / `powershell`

This is a hard break (no deprecation aliases) per the issue's own recommendation — the project is pre-1.0 (v0.17.0) and a dual surface would be more confusing than a one-time change to the `eval`/`source` line in shell init files.

Closes #50

## Test plan
- [x] `cargo build`
- [x] `cargo test` (376 tests pass; renamed `clap_help_mentions_bash_subcommand` -> `clap_help_mentions_completions_subcommand` to match the new top-level subcommand name)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] Manually verified `peanutbutter completions bash/zsh/fish/powershell` emit the expected scripts, invalid shell names produce a clap error listing valid choices, and the old top-level `bash`/`zsh`/`fish`/`powershell` subcommands are gone