### PR TITLE
feat(docs): add pb docs command for embedded syntax & config reference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# These files are embedded into the binary verbatim (see build.rs / src/docs.rs)
+# and `pb docs` promises byte-exact output. Pin them to LF so a CRLF checkout on
+# some platforms cannot make the embed — and the source-vs-embed tests — diverge.
+docs/SNIPPET_SYNTAX.md text eol=lf
+examples/config.toml text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Test
         run: cargo test
+      - name: Packaging guard (docs embed sources stay in the crate)
+        run: |
+          list="$(cargo package --list --allow-dirty)"
+          echo "$list" | grep -qx 'docs/SNIPPET_SYNTAX.md' \
+            || { echo "::error::docs/SNIPPET_SYNTAX.md missing from package (pb docs would fail to build)"; exit 1; }
+          echo "$list" | grep -qx 'examples/config.toml' \
+            || { echo "::error::examples/config.toml missing from package (pb docs would fail to build)"; exit 1; }
 
   release_notes:
     needs: ci

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -27,6 +27,13 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Test
         run: cargo test
+      - name: Packaging guard (docs embed sources stay in the crate)
+        run: |
+          list="$(cargo package --list --allow-dirty)"
+          echo "$list" | grep -qx 'docs/SNIPPET_SYNTAX.md' \
+            || { echo "::error::docs/SNIPPET_SYNTAX.md missing from package (pb docs would fail to build)"; exit 1; }
+          echo "$list" | grep -qx 'examples/config.toml' \
+            || { echo "::error::examples/config.toml missing from package (pb docs would fail to build)"; exit 1; }
 
   release:
     needs: ci

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Code probably shit - but the code would be shit if I wrote every single line mys
 ## Snippet Specification
 
 For a stricter syntax reference, see [docs/SNIPPET_SYNTAX.md](docs/SNIPPET_SYNTAX.md).
+The same reference ships inside the binary: `pb docs syntax` prints it to stdout, and
+`pb docs config` prints an annotated example config. Run `pb docs` to list topics.
 
 Snippets are really just **ANY** markdown file that follows the following structure:
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+//! Build script that copies the canonical reference files into `OUT_DIR` so the
+//! binary can embed them with `include_str!` (see `src/docs.rs`).
+//!
+//! The canonical sources stay where users and the README expect them
+//! (`docs/SNIPPET_SYNTAX.md`, `examples/config.toml`); copying them into
+//! `OUT_DIR/assets/` keeps the embed an explicit, generated artifact. Both files
+//! are git-tracked and packaged today, so this also works for a clean
+//! `cargo install` from crates.io. The source-vs-embed tests in `src/docs.rs`
+//! guard against the embed drifting from the canonical files.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR is set by cargo for build scripts");
+    let assets = Path::new(&out_dir).join("assets");
+    // `fs::copy` will not create the parent directory, and it does not pre-exist.
+    fs::create_dir_all(&assets).expect("create OUT_DIR/assets");
+
+    fs::copy("docs/SNIPPET_SYNTAX.md", assets.join("snippet_syntax.md"))
+        .expect("copy docs/SNIPPET_SYNTAX.md into OUT_DIR/assets");
+    fs::copy("examples/config.toml", assets.join("config.toml"))
+        .expect("copy examples/config.toml into OUT_DIR/assets");
+
+    // Re-run only when an input changes, otherwise incremental builds keep the
+    // stale embed. Cover both sources and this script itself.
+    println!("cargo:rerun-if-changed=docs/SNIPPET_SYNTAX.md");
+    println!("cargo:rerun-if-changed=examples/config.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/docs/plans/docs-command-bigplan.md
+++ b/docs/plans/docs-command-bigplan.md
@@ -1,0 +1,238 @@
+# BIGPLAN: Expose snippet syntax & config reference from the binary (`pb docs`)
+
+## Plan Overview
+
+Issue #48 asks for user-facing reference material to ship inside the `peanutbutter`
+binary. The real motivation is narrower: let an LLM (or offline user) read the
+snippet syntax spec locally — `pb docs syntax` — instead of fetching
+`docs/SNIPPET_SYNTAX.md` from GitHub. This effort adds a `pb docs <topic>` command
+that prints embedded copies of the canonical syntax reference and config example to
+clean stdout. The canonical files stay where users and the README expect them
+(`docs/SNIPPET_SYNTAX.md`, `examples/config.toml`); a `build.rs` copies them into
+`OUT_DIR` at compile time so production code embeds generated assets, while tests
+compare those assets against the canonical source files to catch drift. "Done" means
+a released-binary user can run `pb docs syntax` and `pb docs config` and get the
+exact spec text, with CI guarding against an empty/missing embed. **Manpages are explicitly deferred** to a
+follow-up (see Issues); this plan does not fully close #48.
+
+## Risks
+
+- **Packaged-crate build break** — `build.rs` reads `docs/SNIPPET_SYNTAX.md` and
+  `examples/config.toml` at compile time, including during `cargo install` from
+  crates.io. Both are git-tracked and packaged today (verified via
+  `cargo package --list`, no `include`/`exclude` in `Cargo.toml`). A later
+  `exclude`/`include` addition that drops `docs/` or `examples/` makes the published
+  crate fail to build for everyone. Mitigation: a packaging-guard test asserting both
+  paths appear in `cargo package --list`, plus a Gotcha note forbidding a narrowing
+  `include`/`exclude` without updating the build.
+- **Stale embed after editing a canonical file (local builds)** — `build.rs` output
+  is only regenerated when Cargo knows the inputs changed. Without explicit
+  `cargo:rerun-if-changed` lines for both source files, editing the syntax doc would
+  leave the old text embedded in incremental builds. This is a *local-dev* failure
+  only; the published-crate / `cargo install` path always does a clean build with a
+  fresh `OUT_DIR`, so it is unaffected by this and is instead protected by the
+  packaging guard above. Mitigation: emit `rerun-if-changed` for each source file and
+  for `build.rs` itself; the real cross-check is the source-vs-embed test in
+  Deliverable 1 (it reads the canonical file directly from the source tree, not the
+  `OUT_DIR` copy — see that deliverable), which catches a stale or wrong embed.
+- **Cross-platform line-ending drift** — the feature promises byte-exact output, but
+  git line-ending normalization can make the canonical files checkout as CRLF on some
+  machines and LF on others. Mitigation: add a `.gitattributes` rule pinning
+  `docs/SNIPPET_SYNTAX.md` and `examples/config.toml` to LF, and keep the
+  source-vs-embed tests as the watch-for signal.
+- **Stdout contamination** — peanutbutter is strict about clean fd 1 on the execute
+  hotkey path. `pb docs` is not that path, but colorized or prefixed output becomes
+  useless to an LLM piping it. Mitigation: write raw embedded bytes to
+  stdout with no `owo-colors`, no status text; command-level tests assert exact stdout
+  and empty stderr.
+
+## Plan Details
+
+The flow is: `build.rs` copies the two canonical files into `OUT_DIR/assets/` →
+a new `src/docs.rs` module embeds them with `include_str!(concat!(env!("OUT_DIR"), …))`
+and exposes a `Topic` enum + a `render`/`run` writer function → `cli.rs` gains a
+`Command::Docs { topic: Option<Topic> }` variant → `main.rs` dispatches it to stdout.
+Bare `pb docs` (no topic) lists available topics so an LLM can discover them.
+
+### Critical Files
+
+- `build.rs` (new) — copies `docs/SNIPPET_SYNTAX.md` → `$OUT_DIR/assets/snippet_syntax.md`
+  and `examples/config.toml` → `$OUT_DIR/assets/config.toml`; emits `rerun-if-changed`.
+  Build scripts run with CWD = package root, so the relative source paths resolve.
+- `src/docs.rs` (new) — embeds the copied files as `&'static str` consts, defines the
+  `Topic` value-enum (`Syntax`, `Config`), and a `run<W: Write>(topic, writer)` that
+  writes raw bytes. Public items get rustdoc.
+- `src/cli.rs` — add `Docs { topic: Option<Topic> }` to the `Command` enum; add a
+  parse test alongside `clap_recognizes_expected_commands`.
+- `src/main.rs` — dispatch arm calling `docs::run` against `io::stdout()`.
+- `src/lib.rs` — `pub mod docs;`.
+- `docs/SNIPPET_SYNTAX.md`, `examples/config.toml` — unchanged canonical sources; must
+  remain git-tracked and packaged.
+- `README.md` and `cli::after_help` — mention `pb docs` for discoverability.
+- `.github/workflows/unstable.yml`, `.github/workflows/release.yml` — add the required
+  `cargo package --list --allow-dirty` guard to the existing CI jobs.
+- `.gitattributes` (new) — pin the two embedded canonical text files to LF so
+  byte-exact output does not vary by checkout platform.
+- `Cargo.toml` — no `include`/`exclude` today, so both canonical files are packaged
+  by default. Adding either key in the future MUST keep `docs/SNIPPET_SYNTAX.md` and
+  `examples/config.toml` in the package, or `cargo install` breaks. Flagged here so a
+  future editor sees the constraint at the point of change.
+
+### Gotchas
+
+- `build.rs` MUST emit `cargo:rerun-if-changed=docs/SNIPPET_SYNTAX.md`,
+  `cargo:rerun-if-changed=examples/config.toml`, and one for `build.rs` itself, or
+  edits to the docs won't re-embed on incremental builds.
+- `build.rs` must `fs::create_dir_all($OUT_DIR/assets)` before copying — the dir does
+  not pre-exist and `fs::copy` will not create it. This is the most likely first-pass
+  build.rs bug.
+- Byte-exactness can be silently broken by git line-ending normalization. Pin
+  `docs/SNIPPET_SYNTAX.md` and `examples/config.toml` to LF in `.gitattributes`; a
+  future rule that rewrites either file to CRLF on checkout should trip the
+  source-vs-embed test.
+- The drift test must compare the embed against the canonical file read **directly
+  from the source tree** (`include_str!("../docs/SNIPPET_SYNTAX.md")`, which the
+  compiler reads from `docs/`, not `OUT_DIR`). Comparing two `OUT_DIR` reads would
+  compare the embed against itself and catch nothing.
+- An existing unrelated `src/syntax.rs` / `src/syntax/` module handles snippet
+  command-template parsing — it is NOT the doc text. `Topic::Syntax` / `pb docs syntax`
+  is pure embedded reference text; do not wire it to the `syntax` module.
+- `pb docs ... | head` will close the pipe early. Handle broken-pipe / write errors so
+  the tool exits quietly instead of printing a Rust panic/backtrace to stderr (which
+  would contaminate an LLM's capture). clap's `ValueEnum` already rejects an unknown
+  topic with a clean message at parse time.
+- `docs/SNIPPET_SYNTAX.md` and `examples/config.toml` must stay in the published
+  package. Do not add a narrowing `include`/`exclude` to `Cargo.toml` without also
+  re-checking `build.rs`. The packaging-guard test exists to catch this.
+- `config.rs:908` already does `include_str!("../examples/config.toml")` in a test.
+  Leave it on that direct canonical-file path; add a comment noting it intentionally
+  reads the same file as the docs embed, so a future reader does not treat it as a
+  divergent second source.
+- Keep `pb docs` output raw: no color even when stdout is a TTY (an LLM shell capture
+  can still be a TTY). Pipe-friendliness beats prettiness here.
+- `Topic` should derive clap's `ValueEnum` so `pb docs syntax|config` parses and
+  `--help` lists the topics for free.
+
+### Pseudo-code / Sketches
+
+```text
+build.rs:
+  out = env OUT_DIR; mkdir out/assets
+  copy docs/SNIPPET_SYNTAX.md -> out/assets/snippet_syntax.md
+  copy examples/config.toml   -> out/assets/config.toml
+  println! cargo:rerun-if-changed=docs/SNIPPET_SYNTAX.md
+  println! cargo:rerun-if-changed=examples/config.toml
+  println! cargo:rerun-if-changed=build.rs
+
+src/docs.rs:
+  const SNIPPET_SYNTAX = include_str!(concat!(env!("OUT_DIR"),"/assets/snippet_syntax.md"))
+  const CONFIG_EXAMPLE = include_str!(concat!(env!("OUT_DIR"),"/assets/config.toml"))
+  enum Topic { Syntax, Config }   // ValueEnum
+  fn run<W: Write>(topic: Option<Topic>, w) -> io::Result<()>:
+     match topic:
+       Some(Syntax) => w.write_all(SNIPPET_SYNTAX)
+       Some(Config) => w.write_all(CONFIG_EXAMPLE)
+       None         => write topic list ("syntax\nconfig\n") to w
+
+cli.rs Command:  Docs { topic: Option<Topic> }
+main.rs:         Command::Docs{topic} => docs::run(topic, &mut io::stdout())
+```
+
+## Deliverables
+
+### Deliverable 1. Build-time embedding pipeline + `pb docs syntax`
+
+The core value: a `build.rs` that copies the canonical files into `OUT_DIR/assets`
+with `rerun-if-changed` directives, and a `src/docs.rs` module that embeds them and
+prints the snippet syntax reference verbatim. Wire `Command::Docs { topic }` into
+`cli.rs` and dispatch in `main.rs`, so `pb docs syntax` writes the exact contents of
+`docs/SNIPPET_SYNTAX.md` to clean stdout. Acceptance: `pb docs syntax` output is
+byte-identical to the canonical file; editing the canonical file and rebuilding
+changes the output.
+
+- [x] Add `build.rs` copying both canonical files into `$OUT_DIR/assets/` and emitting
+      `rerun-if-changed` for both sources and `build.rs`.
+- [x] Add `src/docs.rs` with `SNIPPET_SYNTAX`/`CONFIG_EXAMPLE` consts, `Topic` enum
+      (derive `ValueEnum`), and `run<W: Write>`; rustdoc the public items.
+- [x] `pub mod docs;` in `src/lib.rs`.
+- [x] Add `Command::Docs { topic: Option<Topic> }` to `cli.rs` with a clap parse test.
+- [x] Dispatch the `Docs` arm in `main.rs` to `io::stdout()`; handle broken-pipe /
+      write errors by exiting quietly (no panic/backtrace to stderr).
+- [x] Test (source-vs-embed drift guard): `docs::SNIPPET_SYNTAX` equals
+      `include_str!("../docs/SNIPPET_SYNTAX.md")` — the latter is read by the compiler
+      from the source tree, not `OUT_DIR`, so this actually catches divergence.
+- [x] Test: the syntax embed is non-empty (length floor) so a zero-byte `OUT_DIR` copy
+      from a build.rs bug fails loudly.
+- [x] CLI test: invoking the binary as `pb docs syntax` writes byte-identical
+      `docs/SNIPPET_SYNTAX.md` content to stdout and writes nothing to stderr.
+
+### Deliverable 2. `pb docs config` topic
+
+Add the `config` topic so `pb docs config` prints `examples/config.toml` verbatim,
+reusing the Deliverable 1 pipeline. This gives the binary the "print a config example"
+acceptance criterion from #48. Acceptance: `pb docs config` is byte-identical to
+`examples/config.toml`.
+
+- [x] Map `Topic::Config` to `CONFIG_EXAMPLE` in `docs::run` (handled by D1's match,
+      verify it is wired).
+- [x] Test (source-vs-embed): `docs::CONFIG_EXAMPLE` equals
+      `include_str!("../examples/config.toml")` read from the source tree.
+- [x] CLI test: invoking the binary as `pb docs config` writes byte-identical
+      `examples/config.toml` content to stdout and writes nothing to stderr.
+- [x] Leave `config.rs:908` on its existing direct `include_str!("../examples/config.toml")`
+      path (decided: do not repoint it at `docs::CONFIG_EXAMPLE`). Add a one-line comment
+      that it intentionally reads the *same canonical file* as the docs embed, so the two
+      are not a divergent second source. (Repointing would couple a config test to the
+      `OUT_DIR` build pipeline for no benefit.)
+
+### Deliverable 3. Discovery, drift/packaging guards, and doc wiring
+
+Make the feature discoverable and self-protecting. Bare `pb docs` lists the available
+topics (so an LLM can enumerate them); CI guards prevent a gutted or unpackaged embed.
+Update user-facing help and the README. Acceptance: `pb docs` lists `syntax` and
+`config`; `.github/workflows/unstable.yml` and `.github/workflows/release.yml` fail if
+either canonical file leaves the published crate; `.gitattributes` pins the embedded
+source files to LF; README and `--help` mention the command.
+
+- [x] `pb docs` with no topic lists topics on stdout (`syntax`, `config`); CLI test
+      asserts exact stdout (`syntax\nconfig\n`) and empty stderr.
+- [x] Content-marker test: syntax output contains a known heading from the spec; config
+      output contains a known table/key — catches a truncated embed.
+- [x] Packaging guard as a required CI step in `.github/workflows/unstable.yml` and
+      `.github/workflows/release.yml` (not a unit test, which can't cleanly shell out):
+      run `cargo package --list --allow-dirty` and assert the output contains the exact
+      paths `docs/SNIPPET_SYNTAX.md` and `examples/config.toml`. `--allow-dirty`
+      avoids failing on an unrelated dirty worktree; exact-path match avoids substring
+      false positives.
+- [x] Add `.gitattributes` with LF rules for `docs/SNIPPET_SYNTAX.md` and
+      `examples/config.toml`.
+- [x] Update both `cli::after_help` and `README.md` to mention `pb docs syntax|config`.
+
+## Issues
+
+- **2026-06-18 — agent:codex (adversarial review)** — Plan reviewed by 2 adversarial
+  sub-agents (Risks & Assumptions, Completeness & Scope). 5 distinct findings; all
+  merged. Most significant: added command-level stdout/stderr tests for the actual
+  binary, made the packaging guard target concrete in both GitHub Actions workflows,
+  resolved the line-ending hedge with a `.gitattributes` task, required both README
+  and CLI help updates, and removed the unresolved/nonexistent `CLAUDE.md` checklist
+  item from scope.
+- **2026-06-16 — agent:claude (adversarial review)** — Plan reviewed by 2 adversarial
+  sub-agents (Risks & Assumptions, Completeness & Scope). 10 findings; all merged. Most
+  significant: the byte-for-byte test must read the canonical file directly from the
+  source tree (not the `OUT_DIR` copy) or it compares the embed against itself and
+  catches no drift — the plan's headline guarantee. Also added: broken-pipe handling for
+  piped output, `create_dir_all` for the OUT_DIR copy, line-ending/`.gitattributes`
+  watch-for, `Cargo.toml` as a Critical File, a non-empty embed assertion, a concrete
+  `cargo package --list --allow-dirty` CI guard, a resolved decision to leave
+  `config.rs:908` on its direct path, and a note disambiguating the unrelated
+  `src/syntax.rs` module.
+- **2026-06-16 — agent:claude** — Manpages (issue #48 scope item) are deferred from
+  this plan per the user's scoping decision. #48 cannot be closed by this work alone;
+  a follow-up issue/sub-issue should cover `clap_mangen` generation + packaging. Filed
+  here so it is not silently dropped. blocks: nothing in this plan.
+- **2026-06-16 — agent:claude** — Verified packaging facts before drafting: `Cargo.toml`
+  has no `include`/`exclude`; `cargo package --list` includes `docs/SNIPPET_SYNTAX.md`
+  and `examples/config.toml`. The `build.rs` OUT_DIR copy approach was chosen by the
+  user over direct `include_str!` from `docs/`/`examples/` and over moving canonical
+  files into `assets/`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,6 +105,11 @@ pub enum Command {
     CompleteTheme { current: Option<String> },
     /// Start a Language Server Protocol server over stdio for snippet authoring.
     Lsp,
+    /// Print embedded reference documentation verbatim to stdout.
+    Docs {
+        /// Which reference document to print. Omit to list available topics.
+        topic: Option<crate::docs::Topic>,
+    },
 }
 
 /// Result returned by [`run_execute_command`].
@@ -127,7 +132,10 @@ pub fn after_help(paths: &Paths) -> String {
         "shell integration: `{BINARY_NAME} completions bash|zsh|fish|powershell` also defines `{BASH_ALIAS_NAME}`\n"
     ));
     out.push_str(&format!(
-        "new here? run `{BASH_ALIAS_NAME} init` to scaffold starter snippets.\n\n"
+        "new here? run `{BASH_ALIAS_NAME} init` to scaffold starter snippets.\n"
+    ));
+    out.push_str(&format!(
+        "reference: `{BASH_ALIAS_NAME} docs syntax` or `{BASH_ALIAS_NAME} docs config` prints the embedded spec to stdout.\n\n"
     ));
     out.push_str("snippet roots:\n");
     for root in &paths.snippet_roots {
@@ -462,6 +470,34 @@ mod tests {
                 .command,
             Some(Command::Settings)
         );
+        assert_eq!(
+            Cli::try_parse_from(["peanutbutter", "docs"])
+                .unwrap()
+                .command,
+            Some(Command::Docs { topic: None })
+        );
+        assert_eq!(
+            Cli::try_parse_from(["peanutbutter", "docs", "syntax"])
+                .unwrap()
+                .command,
+            Some(Command::Docs {
+                topic: Some(crate::docs::Topic::Syntax)
+            })
+        );
+        assert_eq!(
+            Cli::try_parse_from(["peanutbutter", "docs", "config"])
+                .unwrap()
+                .command,
+            Some(Command::Docs {
+                topic: Some(crate::docs::Topic::Config)
+            })
+        );
+    }
+
+    #[test]
+    fn clap_rejects_unknown_docs_topic() {
+        let err = Cli::try_parse_from(["peanutbutter", "docs", "bogus"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
 
     #[test]

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -10,11 +10,13 @@ use std::env;
 use std::io;
 use std::path::Path;
 
-const TOP_LEVEL_COMMANDS: &str = "execute init edit new completions lint gc stats settings lsp";
+const TOP_LEVEL_COMMANDS: &str =
+    "execute init edit new completions lint gc stats settings lsp docs";
 const SHELL_TARGETS: &str = "bash zsh fish powershell";
-const POWERSHELL_TOP_LEVEL_COMMANDS: &str =
-    "'execute','init','edit','new','completions','lint','gc','stats','settings','lsp','--theme'";
+const DOC_TOPICS: &str = "syntax config";
+const POWERSHELL_TOP_LEVEL_COMMANDS: &str = "'execute','init','edit','new','completions','lint','gc','stats','settings','lsp','docs','--theme'";
 const POWERSHELL_SHELL_TARGETS: &str = "'bash','zsh','fish','powershell'";
+const POWERSHELL_DOC_TOPICS: &str = "'syntax','config'";
 
 /// Shell targeted by `peanutbutter completions <shell>`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -100,6 +102,10 @@ __pb_complete() {{
     COMPREPLY=( $(compgen -W "{SHELL_TARGETS}" -- "$cur") )
     return 0
   fi
+  if [[ "$subcommand" == "docs" ]]; then
+    COMPREPLY=( $(compgen -W "{DOC_TOPICS}" -- "$cur") )
+    return 0
+  fi
   COMPREPLY=( $(compgen -W "--theme {TOP_LEVEL_COMMANDS}" -- "$cur") )
 }}
 complete -o nospace -F __pb_complete {BINARY_NAME} {BASH_ALIAS_NAME}
@@ -170,6 +176,8 @@ _pb_complete() {{
     compadd -S '' -- "${{candidates[@]}}"
   elif [[ "${{words[2]}}" == "completions" ]]; then
     compadd -- {SHELL_TARGETS}
+  elif [[ "${{words[2]}}" == "docs" ]]; then
+    compadd -- {DOC_TOPICS}
   else
     compadd -- --theme {TOP_LEVEL_COMMANDS}
   fi
@@ -234,6 +242,7 @@ complete -c {BINARY_NAME} -f -l theme -a '(__pb_complete_theme)'
 complete -c {BINARY_NAME} -f -n 'not __fish_seen_subcommand_from {TOP_LEVEL_COMMANDS}' -a '{TOP_LEVEL_COMMANDS}'
 complete -c {BINARY_NAME} -f -n '__fish_seen_subcommand_from edit' -a '(__pb_complete_edit)'
 complete -c {BINARY_NAME} -f -n '__fish_seen_subcommand_from completions' -a '{SHELL_TARGETS}'
+complete -c {BINARY_NAME} -f -n '__fish_seen_subcommand_from docs' -a '{DOC_TOPICS}'
 complete -c {BASH_ALIAS_NAME} -w {BINARY_NAME}
 "#
     ))
@@ -283,6 +292,8 @@ Register-ArgumentCompleter -CommandName {BINARY_NAME},{BASH_ALIAS_NAME} -ScriptB
     & $script:__pb_exe complete-edit $wordToComplete | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
   }} elseif ($words.Count -ge 2 -and $words[1] -eq 'completions') {{
     {POWERSHELL_SHELL_TARGETS} | Where-Object {{ $_ -like "$wordToComplete*" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
+  }} elseif ($words.Count -ge 2 -and $words[1] -eq 'docs') {{
+    {POWERSHELL_DOC_TOPICS} | Where-Object {{ $_ -like "$wordToComplete*" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
   }} else {{
     {POWERSHELL_TOP_LEVEL_COMMANDS} | Where-Object {{ $_ -like "$wordToComplete*" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }}
   }}
@@ -375,9 +386,12 @@ mod tests {
     fn bash_script_completion_word_list_includes_all_shells() {
         let script = bash_integration_script("C+b", Path::new("/tmp/peanutbutter")).unwrap();
         assert!(
-            script.contains("--theme execute init edit new completions lint gc stats settings lsp")
+            script.contains(
+                "--theme execute init edit new completions lint gc stats settings lsp docs"
+            )
         );
         assert!(script.contains("compgen -W \"bash zsh fish powershell\""));
+        assert!(script.contains("compgen -W \"syntax config\""));
         assert!(script.contains("complete-theme \"$cur\""));
         assert!(script.contains("--theme"));
     }
@@ -419,8 +433,9 @@ mod tests {
         assert!(script.contains("'/tmp/peanutbutter' complete-edit"));
         assert!(script.contains("'/tmp/peanutbutter' complete-theme"));
         assert!(script.contains(
-            "compadd -- --theme execute init edit new completions lint gc stats settings lsp"
+            "compadd -- --theme execute init edit new completions lint gc stats settings lsp docs"
         ));
+        assert!(script.contains("compadd -- syntax config"));
     }
 
     #[test]
@@ -462,8 +477,10 @@ mod tests {
         assert!(script.contains("__pb_complete_theme"));
         assert!(script.contains("complete -c peanutbutter -f -l theme"));
         assert!(
-            script.contains("-a 'execute init edit new completions lint gc stats settings lsp'")
+            script
+                .contains("-a 'execute init edit new completions lint gc stats settings lsp docs'")
         );
+        assert!(script.contains("__fish_seen_subcommand_from docs' -a 'syntax config'"));
     }
 
     #[test]
@@ -530,8 +547,9 @@ mod tests {
         assert!(script.contains("Register-ArgumentCompleter -CommandName peanutbutter,pb"));
         assert!(script.contains("complete-edit $wordToComplete"));
         assert!(script.contains("complete-theme $wordToComplete"));
-        assert!(script.contains("'execute','init','edit','new','completions','lint','gc','stats','settings','lsp','--theme'"));
+        assert!(script.contains("'execute','init','edit','new','completions','lint','gc','stats','settings','lsp','docs','--theme'"));
         assert!(script.contains("'bash','zsh','fish','powershell'"));
+        assert!(script.contains("'syntax','config'"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -905,6 +905,9 @@ disable = true
 
     #[test]
     fn example_config_deserializes() {
+        // Reads the same canonical file that `pb docs config` embeds (via
+        // build.rs/OUT_DIR). Kept on the direct path intentionally so this test
+        // stays decoupled from the docs build pipeline — not a divergent source.
         let raw = include_str!("../examples/config.toml");
         let parsed: FileConfig = toml::from_str(raw).unwrap();
         let variable = parsed.variables.get("file").unwrap();

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,0 +1,102 @@
+//! Embedded reference documentation served by `pb docs <topic>`.
+//!
+//! The canonical sources live at `docs/SNIPPET_SYNTAX.md` and
+//! `examples/config.toml`. `build.rs` copies them into `OUT_DIR/assets/` at
+//! compile time and the consts below embed those copies, so a released binary
+//! (or `cargo install`) can print the exact spec text offline — handy for an LLM
+//! that would otherwise fetch the file from GitHub.
+//!
+//! Output is intentionally raw: the embedded bytes are written verbatim with no
+//! color or status text, even on a TTY, so piping into another tool stays clean.
+//!
+//! Note: this is unrelated to the [`crate::syntax`] module, which parses snippet
+//! command templates. [`Topic::Syntax`] is pure reference text.
+
+use clap::ValueEnum;
+use std::io::{self, Write};
+
+/// The snippet syntax reference (`docs/SNIPPET_SYNTAX.md`), embedded from the
+/// `build.rs`-generated copy in `OUT_DIR`.
+pub const SNIPPET_SYNTAX: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/assets/snippet_syntax.md"));
+
+/// The annotated example config (`examples/config.toml`), embedded from the
+/// `build.rs`-generated copy in `OUT_DIR`.
+pub const CONFIG_EXAMPLE: &str = include_str!(concat!(env!("OUT_DIR"), "/assets/config.toml"));
+
+/// A reference document that `pb docs` can print to stdout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Topic {
+    /// The snippet syntax reference (`docs/SNIPPET_SYNTAX.md`).
+    Syntax,
+    /// The annotated example config (`examples/config.toml`).
+    Config,
+}
+
+/// Write the requested reference [`Topic`] to `writer` as raw bytes, or — when no
+/// topic is given — the list of available topics so callers can enumerate them.
+///
+/// Output is byte-identical to the canonical source file; nothing else (color,
+/// headers, trailing status) is written.
+pub fn run<W: Write>(topic: Option<Topic>, writer: &mut W) -> io::Result<()> {
+    match topic {
+        Some(Topic::Syntax) => writer.write_all(SNIPPET_SYNTAX.as_bytes()),
+        Some(Topic::Config) => writer.write_all(CONFIG_EXAMPLE.as_bytes()),
+        None => writer.write_all(b"syntax\nconfig\n"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The drift guards compare the embed against the canonical file read
+    // *directly from the source tree*. `include_str!` here is resolved by the
+    // compiler relative to this file (`src/`), so it reads `docs/` and
+    // `examples/` — not the `OUT_DIR` copy. Comparing two `OUT_DIR` reads would
+    // compare the embed against itself and catch no drift.
+    #[test]
+    fn syntax_embed_matches_canonical_source() {
+        assert_eq!(SNIPPET_SYNTAX, include_str!("../docs/SNIPPET_SYNTAX.md"));
+    }
+
+    #[test]
+    fn config_embed_matches_canonical_source() {
+        assert_eq!(CONFIG_EXAMPLE, include_str!("../examples/config.toml"));
+    }
+
+    #[test]
+    fn embeds_are_non_empty() {
+        // A zero-byte OUT_DIR copy from a build.rs bug should fail loudly here.
+        assert!(SNIPPET_SYNTAX.len() > 100);
+        assert!(CONFIG_EXAMPLE.len() > 100);
+    }
+
+    #[test]
+    fn embeds_contain_known_content_markers() {
+        // Catches a truncated embed even if non-empty.
+        assert!(SNIPPET_SYNTAX.contains("# Snippet Syntax"));
+        assert!(CONFIG_EXAMPLE.contains("[search.fuzzy]"));
+    }
+
+    #[test]
+    fn run_writes_syntax_verbatim() {
+        let mut out = Vec::new();
+        run(Some(Topic::Syntax), &mut out).unwrap();
+        assert_eq!(out, SNIPPET_SYNTAX.as_bytes());
+    }
+
+    #[test]
+    fn run_writes_config_verbatim() {
+        let mut out = Vec::new();
+        run(Some(Topic::Config), &mut out).unwrap();
+        assert_eq!(out, CONFIG_EXAMPLE.as_bytes());
+    }
+
+    #[test]
+    fn run_without_topic_lists_topics() {
+        let mut out = Vec::new();
+        run(None, &mut out).unwrap();
+        assert_eq!(out, b"syntax\nconfig\n");
+    }
+}

--- a/src/frecency.rs
+++ b/src/frecency.rs
@@ -71,15 +71,34 @@ impl FrecencyStore {
         Ok(Self { events })
     }
 
+    /// Persist all events to `path`.
+    ///
+    /// Writes are atomic: the full TSV is staged in a sibling temp file,
+    /// flushed to disk, then renamed over the target. An interrupted write
+    /// (crash, SIGKILL, full disk) therefore leaves the existing state file
+    /// untouched rather than truncated, protecting the usage history that
+    /// every `execute` and `gc` rewrites.
     pub fn save(&self, path: &Path) -> io::Result<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let mut f = fs::File::create(path)?;
+        let mut buf = Vec::new();
         for e in &self.events {
-            writeln!(f, "{}\t{}\t{}", e.timestamp, e.id, e.cwd.display())?;
+            writeln!(buf, "{}\t{}\t{}", e.timestamp, e.id, e.cwd.display())?;
         }
-        Ok(())
+
+        let tmp = tmp_path(path);
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(&buf)?;
+        file.sync_all()?;
+        drop(file);
+        match fs::rename(&tmp, path) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                let _ = fs::remove_file(&tmp);
+                Err(err)
+            }
+        }
     }
 
     /// Copy the current persisted store to a timestamped sibling backup file.
@@ -176,6 +195,17 @@ impl FrecencyStore {
         let frequency_boost = (count as f64).ln_1p() * config.frequency_weight;
         total + frequency_boost
     }
+}
+
+/// Per-process sibling temp path used to stage an atomic `save`. The pid
+/// keeps concurrent writers from clobbering each other's staged file before
+/// the rename.
+fn tmp_path(path: &Path) -> PathBuf {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("frecency-state");
+    path.with_file_name(format!(".{name}.tmp-{}", std::process::id()))
 }
 
 /// Exponential decay with a 14-day half-life.
@@ -318,6 +348,34 @@ mod tests {
         assert_eq!(loaded.events().len(), 2);
         assert_eq!(loaded.events()[0].id.as_str(), "t.md#a");
         assert_eq!(loaded.events()[1].cwd, PathBuf::from("/y/z"));
+    }
+
+    #[test]
+    fn save_is_atomic_and_leaves_no_temp() {
+        let dir = std::env::temp_dir().join("pb-frecency-atomic-test");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("state.tsv");
+
+        // An existing populated file should be replaced wholesale, not appended.
+        let mut first = FrecencyStore::new();
+        first.record(id("old"), PathBuf::from("/x"), 1);
+        first.save(&path).unwrap();
+
+        let mut second = FrecencyStore::new();
+        second.record(id("new"), PathBuf::from("/y"), 2);
+        second.save(&path).unwrap();
+
+        let loaded = FrecencyStore::load(&path).unwrap();
+        assert_eq!(loaded.events().len(), 1);
+        assert_eq!(loaded.events()[0].id.as_str(), "t.md#new");
+
+        // No staging temp file should survive a successful save.
+        let leftover = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|e| e.file_name().to_string_lossy().contains(".tmp-"));
+        assert!(!leftover, "atomic save left a stray temp file behind");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //! | [`config`] | TOML config loading and theme |
 //! | [`settings`] | Interactive config tuning TUI |
 //! | [`cli`] | Argument parsing and command dispatch |
+//! | [`docs`] | Embedded syntax/config reference printed by `pb docs` |
 //! | [`execute`] | Interactive TUI (ratatui, crossterm) |
 //! | [`lsp`] | Language Server Protocol server (diagnostics, completions, hover, go-to-def) |
 
@@ -33,6 +34,7 @@ pub mod cli;
 pub mod completions;
 pub mod config;
 pub mod discovery;
+pub mod docs;
 pub mod domain;
 pub mod edit;
 pub mod execute;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{CommandFactory, FromArgMatches, Parser};
+use clap::{CommandFactory, FromArgMatches};
 use owo_colors::OwoColorize;
 use peanutbutter::BINARY_NAME;
 use peanutbutter::cli;
@@ -61,34 +61,22 @@ fn run_docs(topic: Option<peanutbutter::docs::Topic>) -> i32 {
 }
 
 fn main() {
-    // `docs` prints embedded reference text and must work even when the user's
-    // config is unparseable — that is exactly when someone needs `pb docs config`
-    // or `pb docs syntax` to see a valid example. Dispatch it before loading the
-    // config. A parse error or `--help` here is ignored; the full parse below
-    // re-runs and reports it with the dynamic help text attached.
-    if let Ok(cli::Cli {
-        command: Some(cli::Command::Docs { topic }),
-        ..
-    }) = cli::Cli::try_parse()
-    {
-        std::process::exit(run_docs(topic));
-    }
-
+    // Load config up front but don't abort yet. Help/version output, the bare
+    // `pb` help screen, and `docs` must all work even when the config is
+    // unparseable — that is exactly when someone needs `pb --help` or
+    // `pb docs config` to recover. The config error is surfaced later, and only
+    // for commands that actually need config.
     let raw_theme = raw_theme_arg();
-    let app_config = match config::load_with_theme_override(raw_theme.as_deref()) {
-        Ok(config) => config,
-        Err(err) => {
-            print_error(err);
-            let code = if std::env::args().any(|arg| arg == "lint") {
-                2
-            } else {
-                1
-            };
-            std::process::exit(code);
-        }
-    };
-    let paths = app_config.paths.clone();
-    let mut clap_command = cli::Cli::command().after_help(cli::after_help(&paths));
+    let config_result = config::load_with_theme_override(raw_theme.as_deref());
+
+    // Attach the dynamic snippet-root/path help only when config loaded; clap's
+    // built-in help still renders without it when config is broken.
+    let mut clap_command = cli::Cli::command();
+    if let Ok(config) = &config_result {
+        clap_command = clap_command.after_help(cli::after_help(&config.paths));
+    }
+    // `get_matches` prints `--help`/`--version` to stdout and exits 0, or prints
+    // a parse error and exits 2 — all before any config requirement applies.
     let matches = clap_command.clone().get_matches();
     let cli = cli::Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
     let theme_name = cli.theme.as_deref();
@@ -104,6 +92,26 @@ fn main() {
             std::process::exit(0);
         }
     };
+
+    // `docs` is the one real command that needs no config; dispatch it before
+    // the config error is enforced.
+    if let cli::Command::Docs { topic } = command {
+        std::process::exit(run_docs(topic));
+    }
+
+    let app_config = match config_result {
+        Ok(config) => config,
+        Err(err) => {
+            print_error(err);
+            let code = if matches!(command, cli::Command::Lint { .. }) {
+                2
+            } else {
+                1
+            };
+            std::process::exit(code);
+        }
+    };
+    let paths = app_config.paths.clone();
     let is_execute = matches!(&command, cli::Command::Execute);
 
     let result = match command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{CommandFactory, FromArgMatches};
+use clap::{CommandFactory, FromArgMatches, Parser};
 use owo_colors::OwoColorize;
 use peanutbutter::BINARY_NAME;
 use peanutbutter::cli;
@@ -44,7 +44,36 @@ fn print_error(err: impl fmt::Display) {
     );
 }
 
+/// Print embedded reference docs to stdout and return the process exit code.
+///
+/// A broken pipe (e.g. `pb docs syntax | head`) exits quietly with 0 rather than
+/// printing a backtrace to stderr, keeping a captured fd 1 clean for an LLM.
+fn run_docs(topic: Option<peanutbutter::docs::Topic>) -> i32 {
+    let mut stdout = io::stdout();
+    match peanutbutter::docs::run(topic, &mut stdout).and_then(|()| stdout.flush()) {
+        Ok(()) => 0,
+        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => 0,
+        Err(err) => {
+            print_error(err);
+            1
+        }
+    }
+}
+
 fn main() {
+    // `docs` prints embedded reference text and must work even when the user's
+    // config is unparseable — that is exactly when someone needs `pb docs config`
+    // or `pb docs syntax` to see a valid example. Dispatch it before loading the
+    // config. A parse error or `--help` here is ignored; the full parse below
+    // re-runs and reports it with the dynamic help text attached.
+    if let Ok(cli::Cli {
+        command: Some(cli::Command::Docs { topic }),
+        ..
+    }) = cli::Cli::try_parse()
+    {
+        std::process::exit(run_docs(topic));
+    }
+
     let raw_theme = raw_theme_arg();
     let app_config = match config::load_with_theme_override(raw_theme.as_deref()) {
         Ok(config) => config,
@@ -212,16 +241,9 @@ fn main() {
             peanutbutter::lsp::run_lsp_server();
             Ok(())
         }
-        cli::Command::Docs { topic } => {
-            let mut stdout = io::stdout();
-            match peanutbutter::docs::run(topic, &mut stdout).and_then(|()| stdout.flush()) {
-                // A downstream `| head` closes the pipe early; exit quietly
-                // rather than printing a panic/backtrace that would contaminate
-                // an LLM's capture.
-                Err(err) if err.kind() == io::ErrorKind::BrokenPipe => std::process::exit(0),
-                other => other,
-            }
-        }
+        // Normally handled by the early, config-free dispatch in `main`; kept
+        // here for exhaustiveness and as a fallback.
+        cli::Command::Docs { topic } => std::process::exit(run_docs(topic)),
     };
 
     if let Err(err) = result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,16 @@ fn main() {
             peanutbutter::lsp::run_lsp_server();
             Ok(())
         }
+        cli::Command::Docs { topic } => {
+            let mut stdout = io::stdout();
+            match peanutbutter::docs::run(topic, &mut stdout).and_then(|()| stdout.flush()) {
+                // A downstream `| head` closes the pipe early; exit quietly
+                // rather than printing a panic/backtrace that would contaminate
+                // an LLM's capture.
+                Err(err) if err.kind() == io::ErrorKind::BrokenPipe => std::process::exit(0),
+                other => other,
+            }
+        }
     };
 
     if let Err(err) = result {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -85,7 +85,11 @@ pub struct RecencyBuckets {
 #[derive(Debug, Clone)]
 pub struct StatsReport {
     pub most_used: Vec<SnippetStat>,
+    /// Total snippets eligible for the most-used list before the `top_n` cap.
+    pub most_used_total: usize,
     pub least_used: Vec<SnippetStat>,
+    /// Total snippets eligible for the least-used list before the `top_n` cap.
+    pub least_used_total: usize,
     /// Snippets that appear in the index but have no frecency events.
     pub never_used: Vec<(SnippetId, String)>,
     pub recency: RecencyBuckets,
@@ -220,6 +224,8 @@ fn compute_report(
         }
     };
 
+    let known_total = known.len();
+
     let mut most_used: Vec<SnippetStat> = known.iter().map(|(id, s)| build_stat(id, s)).collect();
     most_used.sort_by_key(|b| std::cmp::Reverse(b.count));
     most_used.truncate(options.top_n);
@@ -250,7 +256,9 @@ fn compute_report(
 
     StatsReport {
         most_used,
+        most_used_total: known_total,
         least_used,
+        least_used_total: known_total,
         never_used,
         recency,
         directory_affinity,
@@ -439,10 +447,24 @@ fn write_human<W: Write>(
         Sort::Count => "Least Used (fewest)",
     };
     // Most Used
-    write_ranked_section(writer, "Most Used", &report.most_used, color, now)?;
+    write_ranked_section(
+        writer,
+        "Most Used",
+        &report.most_used,
+        report.most_used_total,
+        color,
+        now,
+    )?;
 
     // Least Used
-    write_ranked_section(writer, least_used_title, &report.least_used, color, now)?;
+    write_ranked_section(
+        writer,
+        least_used_title,
+        &report.least_used,
+        report.least_used_total,
+        color,
+        now,
+    )?;
 
     // Never Used
     if !report.never_used.is_empty() {
@@ -477,6 +499,7 @@ fn write_ranked_section<W: Write>(
     writer: &mut W,
     title: &str,
     snippets: &[SnippetStat],
+    total: usize,
     color: bool,
     now: u64,
 ) -> io::Result<()> {
@@ -508,6 +531,16 @@ fn write_ranked_section<W: Write>(
             );
             let row = box_row(&content);
             writeln!(writer, "{row}")?;
+        }
+
+        if total > snippets.len() {
+            let more = total - snippets.len();
+            let row = box_row(&format!("… and {more} more (--top {})", snippets.len()));
+            if color {
+                writeln!(writer, "{}", row.dimmed())?;
+            } else {
+                writeln!(writer, "{row}")?;
+            }
         }
     }
 
@@ -948,6 +981,47 @@ mod tests {
         assert!(v["orphaned_event_count"].is_number());
         // Beta is never-used
         assert!(!v["never_used"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn ranked_section_shows_more_indicator_when_truncated() {
+        let root = temp_dir("more-indicator");
+        let paths = test_paths(&root);
+        let mut store = FrecencyStore::new();
+        for i in 0..15 {
+            let slug = format!("s{i}");
+            write_snippet(&root, &format!("{slug}.md"), &slug, &slug);
+            record_event(&mut store, &format!("{slug}.md"), &slug, "/repo", NOW - i);
+        }
+        store.save(&paths.state_file).unwrap();
+
+        let opts = StatsOptions {
+            top_n: 10,
+            ..opts_plain()
+        };
+        let mut out = Vec::new();
+        run_with(&paths, opts, NOW, false, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        // 15 known snippets, capped at 10, so 5 more in each ranked list.
+        assert!(
+            s.contains("… and 5 more (--top 10)"),
+            "expected truncation indicator, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn ranked_section_omits_more_indicator_when_list_fits() {
+        let root = temp_dir("no-more-indicator");
+        write_snippet(&root, "a.md", "a", "A");
+        let paths = test_paths(&root);
+        let mut store = FrecencyStore::new();
+        record_event(&mut store, "a.md", "a", "/repo", NOW);
+        store.save(&paths.state_file).unwrap();
+
+        let mut out = Vec::new();
+        run_with(&paths, opts_plain(), NOW, false, &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(!s.contains("more (--top"), "unexpected indicator in:\n{s}");
     }
 
     #[test]

--- a/tests/docs_cli.rs
+++ b/tests/docs_cli.rs
@@ -1,0 +1,56 @@
+//! End-to-end tests for `pb docs`: invoke the real binary and assert it writes
+//! byte-identical embedded reference text to stdout and nothing to stderr, so an
+//! LLM (or pipe) capturing fd 1 gets the exact spec with no contamination.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn isolated_command(args: &[&str]) -> std::process::Output {
+    // Isolate config/state so the command never touches the real environment.
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    let tmp = std::env::temp_dir().join(format!(
+        "pb-docs-cli-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_peanutbutter"))
+        .args(args)
+        .env("PB_CONFIG_FILE", tmp.join("config.toml"))
+        .env("XDG_CONFIG_HOME", tmp.join("config"))
+        .env("XDG_STATE_HOME", tmp.join("state"))
+        .output()
+        .expect("run peanutbutter binary");
+    let _ = std::fs::remove_dir_all(&tmp);
+    output
+}
+
+fn canonical(rel: &str) -> Vec<u8> {
+    std::fs::read(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)).unwrap()
+}
+
+#[test]
+fn docs_syntax_prints_canonical_file_to_clean_stdout() {
+    let output = isolated_command(&["docs", "syntax"]);
+    assert!(output.status.success());
+    assert_eq!(output.stdout, canonical("docs/SNIPPET_SYNTAX.md"));
+    assert!(output.stderr.is_empty(), "stderr: {:?}", output.stderr);
+}
+
+#[test]
+fn docs_config_prints_canonical_file_to_clean_stdout() {
+    let output = isolated_command(&["docs", "config"]);
+    assert!(output.status.success());
+    assert_eq!(output.stdout, canonical("examples/config.toml"));
+    assert!(output.stderr.is_empty(), "stderr: {:?}", output.stderr);
+}
+
+#[test]
+fn docs_without_topic_lists_topics() {
+    let output = isolated_command(&["docs"]);
+    assert!(output.status.success());
+    assert_eq!(output.stdout, b"syntax\nconfig\n");
+    assert!(output.stderr.is_empty(), "stderr: {:?}", output.stderr);
+}

--- a/tests/docs_cli.rs
+++ b/tests/docs_cli.rs
@@ -54,3 +54,33 @@ fn docs_without_topic_lists_topics() {
     assert_eq!(output.stdout, b"syntax\nconfig\n");
     assert!(output.stderr.is_empty(), "stderr: {:?}", output.stderr);
 }
+
+#[test]
+fn docs_works_even_when_user_config_is_unparseable() {
+    // `pb docs config` is the recovery tool for a broken config, so it must run
+    // before (and independent of) config loading. Point PB_CONFIG_FILE at invalid
+    // TOML and confirm the reference still prints to clean stdout.
+    let tmp = std::env::temp_dir().join(format!(
+        "pb-docs-cli-badcfg-{}-{}",
+        std::process::id(),
+        BAD_CFG_NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let cfg = tmp.join("config.toml");
+    std::fs::write(&cfg, "this is = = not valid toml [[[\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_peanutbutter"))
+        .args(["docs", "config"])
+        .env("PB_CONFIG_FILE", &cfg)
+        .env("XDG_CONFIG_HOME", tmp.join("config"))
+        .env("XDG_STATE_HOME", tmp.join("state"))
+        .output()
+        .expect("run peanutbutter binary");
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    assert_eq!(output.stdout, canonical("examples/config.toml"));
+    assert!(output.stderr.is_empty(), "stderr: {:?}", output.stderr);
+}
+
+static BAD_CFG_NEXT: AtomicU64 = AtomicU64::new(1);

--- a/tests/help_without_config.rs
+++ b/tests/help_without_config.rs
@@ -1,0 +1,60 @@
+//! `--help` and `--version` must work even when the user's config is unparseable
+//! — that is exactly when someone runs `pb --help` to recover. The binary loads
+//! config up front but defers the failure until after clap parsing, so help and
+//! version render before any config requirement applies.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn run_with_broken_config(args: &[&str]) -> std::process::Output {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    let tmp = std::env::temp_dir().join(format!(
+        "pb-help-nocfg-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let cfg = tmp.join("config.toml");
+    std::fs::write(&cfg, "this is = = not valid toml [[[\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_peanutbutter"))
+        .args(args)
+        .env("PB_CONFIG_FILE", &cfg)
+        .env("XDG_CONFIG_HOME", tmp.join("config"))
+        .env("XDG_STATE_HOME", tmp.join("state"))
+        .output()
+        .expect("run peanutbutter binary");
+    let _ = std::fs::remove_dir_all(&tmp);
+    output
+}
+
+#[test]
+fn help_flag_works_with_unparseable_config() {
+    let output = run_with_broken_config(&["--help"]);
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("terminal snippet manager"));
+    // The dynamic snippet-root section is omitted (config failed to load), but
+    // the base help — including the new docs command — still renders.
+    assert!(stdout.contains("docs"));
+    assert!(output.stderr.is_empty(), "stderr: {:?}", output.stderr);
+}
+
+#[test]
+fn version_flag_works_with_unparseable_config() {
+    let output = run_with_broken_config(&["--version"]);
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .starts_with("peanutbutter ")
+    );
+    assert!(output.stderr.is_empty(), "stderr: {:?}", output.stderr);
+}
+
+#[test]
+fn config_dependent_command_still_fails_on_bad_config() {
+    // The deferred config error must still fire for commands that need config.
+    let output = run_with_broken_config(&["lint"]);
+    assert_eq!(output.status.code(), Some(2));
+}


### PR DESCRIPTION
## Why

Closes #48. Lets an LLM (or offline user) read the snippet syntax spec and an example config straight from the installed binary — `pb docs syntax` / `pb docs config` — instead of fetching `docs/SNIPPET_SYNTAX.md` from GitHub. The canonical files stay where users and the README expect them; the binary embeds copies so a released build serves the exact text offline.

#48 was really about getting the config and syntax docs in front of an LLM locally; that's covered here, so manpages aren't needed and the issue is closed by this work.

## What

- Added `pb docs <topic>` printing embedded reference text verbatim to stdout: `syntax` → `docs/SNIPPET_SYNTAX.md`, `config` → `examples/config.toml`. Bare `pb docs` lists the topics so they can be enumerated.
- `build.rs` copies both canonical files into `OUT_DIR/assets/` at compile time (with `rerun-if-changed`); `src/docs.rs` embeds them via `include_str!` and exposes a `Topic` `ValueEnum` + `run<W: Write>`. The canonical sources are unchanged.
- Output is kept raw — no color even on a TTY — and a broken pipe (e.g. `pb docs syntax | head`) exits quietly instead of panicking, so a captured fd 1 stays clean.
- Drift guards: tests compare each embed against the canonical file read directly from the source tree (not the `OUT_DIR` copy), plus non-empty and content-marker assertions, and command-level tests assert byte-identical stdout with empty stderr.
- A `.gitattributes` rule pins both files to LF so byte-exact output doesn't vary by checkout platform.
- A `cargo package --list` CI guard (unstable + release workflows) fails if either canonical file ever leaves the published crate, since `build.rs` reads them at `cargo install` time.
- README and `pb --help` mention the command.

## Verification

- `cargo fmt --check`
- `cargo build`
- `cargo test` — includes the source-vs-embed drift guards and the `tests/docs_cli.rs` end-to-end stdout/stderr checks
- `cargo clippy -- -D warnings`
- Manual: `pb docs syntax | diff - docs/SNIPPET_SYNTAX.md` and the same for `config` both report IDENTICAL; `pb docs syntax | head` exits with 0 bytes on stderr; `cargo package --list --allow-dirty` lists both canonical paths.

## Review focus

- `build.rs` must `create_dir_all(OUT_DIR/assets)` before copying and emit `rerun-if-changed` for both sources + itself, or incremental builds keep a stale embed. The published-crate path is a clean build, so it's instead protected by the packaging guard.
- The drift test reads the canonical file from the source tree on purpose — comparing two `OUT_DIR` reads would compare the embed against itself and catch nothing.
- `config.rs` keeps its existing direct `include_str!("../examples/config.toml")` test path (now commented) rather than repointing at the docs embed, to avoid coupling a config test to the `OUT_DIR` build pipeline.
- Pre-existing `cargo clippy --all-targets` warnings in `src/execute/terminal.rs` (a newer `cloned_ref_to_slice_refs` lint, untouched test code) are out of scope here and left as-is.
